### PR TITLE
(docs) Refresh docs for stack v0.7-era bump: Cortex, Memory, system graph

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -7,8 +7,11 @@ on:
     branches: [main]
     paths:
       - "docker/emos/**"
+      - "stack/sugarcoat"
       - "stack/sugarcoat/**"
+      - "stack/embodied-agents"
       - "stack/embodied-agents/**"
+      - "stack/kompass"
       - "stack/kompass/**"
   workflow_dispatch:
 

--- a/.github/workflows/native-install.yml
+++ b/.github/workflows/native-install.yml
@@ -4,15 +4,23 @@ on:
   push:
     branches: [main]
     paths:
+      - "stack/emos-cli"
       - "stack/emos-cli/**"
+      - "stack/sugarcoat"
       - "stack/sugarcoat/**"
+      - "stack/embodied-agents"
       - "stack/embodied-agents/**"
+      - "stack/kompass"
       - "stack/kompass/**"
   pull_request:
     paths:
+      - "stack/emos-cli"
       - "stack/emos-cli/**"
+      - "stack/sugarcoat"
       - "stack/sugarcoat/**"
+      - "stack/embodied-agents"
       - "stack/embodied-agents/**"
+      - "stack/kompass"
       - "stack/kompass/**"
   workflow_dispatch:
 

--- a/.github/workflows/pixi-install.yml
+++ b/.github/workflows/pixi-install.yml
@@ -5,16 +5,24 @@ on:
     branches: [main]
     paths:
       - "pixi.toml"
+      - "stack/emos-cli"
       - "stack/emos-cli/**"
+      - "stack/sugarcoat"
       - "stack/sugarcoat/**"
+      - "stack/embodied-agents"
       - "stack/embodied-agents/**"
+      - "stack/kompass"
       - "stack/kompass/**"
   pull_request:
     paths:
       - "pixi.toml"
+      - "stack/emos-cli"
       - "stack/emos-cli/**"
+      - "stack/sugarcoat"
       - "stack/sugarcoat/**"
+      - "stack/embodied-agents"
       - "stack/embodied-agents/**"
+      - "stack/kompass"
       - "stack/kompass/**"
   workflow_dispatch:
     inputs: {}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,19 @@
+/* === Mermaid handwritten font ===
+   Box and text colours are pinned via the diagram's per-diagram
+   %%{init}%% directive plus classDef declarations */
+@import url('https://fonts.googleapis.com/css2?family=Architects+Daughter&family=Caveat&display=swap');
+
+.mermaid svg text,
+.mermaid .nodeLabel,
+.mermaid .edgeLabel,
+.mermaid .nodeLabel p,
+.mermaid foreignObject span {
+    font-family: 'Architects Daughter', 'Caveat', system-ui, sans-serif !important;
+    font-size: 19px !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.02em !important;
+}
+
 /* === Theme Colors === */
 :root {
     --automatika-primary: #E83F3F;

--- a/docs/concepts/events-and-actions.md
+++ b/docs/concepts/events-and-actions.md
@@ -180,6 +180,40 @@ return_event = Event(needs_return, on_change=True)
 
 ---
 
+## Events from Internal State (a.k.a Generic Events)
+
+Most events watch a topic. Sometimes you need an event whose firing condition is **internal state** that is not being published as a ROS topic -- for example a hardware monitor or a compound signal that requires arbitrary calculation. For these cases, an `Event` accepts a third kind of condition alongside topic predicates: **any Python callable that returns `bool`**, polled at a configurable rate.
+
+```python
+from ros_sugar.event import Event
+from ros_sugar.actions import log
+
+
+def is_overheating() -> bool:           # must be type-annotated as bool
+    return read_temperature() > 75.0    # any internal state goes here
+
+
+# Fires when ``is_overheating()`` returns True; polled twice a second.
+event_overheat = Event(is_overheating, check_rate=2.0)
+
+events_actions = {
+    event_overheat: log(msg="Overheating -- backing off"),
+}
+```
+
+Two rules: the callable's return type annotation **must be `bool`**, and the callable **cannot be a `@component_action`** method bound to a managed component. Use a plain function or a regular instance method. The polling loop runs on the central Monitor; `check_rate` is in Hz and defaults to the Monitor's loop rate when omitted.
+
+```{seealso}
+For a complete worked recipe -- including how to feed the predicate's state from elsewhere in the graph and what the event looks like in the Web UI -- see [Internal-State Events](../recipes/events-and-resilience/internal-state-events.md).
+```
+
+Use this when:
+- The trigger condition is **internal state** that has no business being a topic.
+- You want **derived predicates** that span multiple sources, easier to express as a Python callable that makes arbitrary calculations on them rather than as a chain of topic conditions.
+- You want **encapsulation** -- keep the predicate state inside the recipe rather than pushing it onto a topic just so an event can watch it.
+
+---
+
 ## Actions
 
 **Executable context-aware behaviors for your robotic system.**

--- a/docs/concepts/launcher.md
+++ b/docs/concepts/launcher.md
@@ -99,7 +99,26 @@ Define "Catch-All" policies for the entire system.
 launcher.on_component_fail(action_name="restart")
 ```
 
-### 4. Events Orchestration
+For the further case where an entire **process** crashes (segfault, OOM, native exception) and there is nothing left in-process to dispatch a Fallback, the launcher provides `Launcher.on_process_fail()`. The launcher relaunches any component process that exits with a non-zero status outside of normal shutdown:
+
+```python
+launcher.on_process_fail(max_retries=3)   # respawn up to 3 times per component
+```
+
+See [Process-Level Recovery](status-and-fallbacks.md#process-level-recovery) for the full picture.
+
+### 4. Executor Spin Timeout
+
+```python
+launcher = Launcher(
+    multi_processing=True,
+    executor_spin_timeout=0.05,   # seconds
+)
+```
+
+Each component runs a ROS2 executor that spins its callbacks. The executor blocks for at most this many seconds per spin call regardless of how fast the component's main loop is running. Lower values reduce callback latency at the cost of CPU; the default works for most recipes. Tune this when running latency-sensitive callbacks alongside `on_process_fail` to avoid mistaking a slow callback for a stalled process.
+
+### 5. Events Orchestration
 
 Pass your events/actions dictionary **once** to the `Launcher` and it will handle delegating the event monitoring to the concerned component.
 

--- a/docs/concepts/status-and-fallbacks.md
+++ b/docs/concepts/status-and-fallbacks.md
@@ -2,7 +2,7 @@
 
 **All robots can fail, but smart robots recover.**
 
-EMOS components are **Self-Aware** and **Self-Healing** by design. The Health Status system allows every component to explicitly declare its operational state --- not just "Alive" or "Dead," but *how* it is functioning. When failures are detected, the Fallback system automatically triggers pre-configured recovery strategies, keeping the robot operational without human intervention.
+EMOS components are **Self-Aware** and **Self-Healing** by design. The Health Status system allows every component to explicitly declare its operational state --- not just "Alive" or "Dead," but _how_ it is functioning. When failures are detected, the Fallback system automatically triggers pre-configured recovery strategies, keeping the robot operational without human intervention.
 
 ---
 
@@ -11,10 +11,10 @@ EMOS components are **Self-Aware** and **Self-Healing** by design. The Health St
 The **Health Status** is the heartbeat of an EMOS component. Unlike standard ROS2 nodes, EMOS components differentiate between a math error (Algorithm Failure), a hardware crash (Component Failure), or a missing input (System Failure).
 
 These reports are broadcast back to the system to trigger:
-* {material-regular}`notifications;1.2em;sd-text-warning` **Alerts:** Notify the operator of specific issues.
-* {material-regular}`flash_on;1.2em;sd-text-primary` **Reflexes:** Trigger [Events](events-and-actions.md) to handle the situation.
-* {material-regular}`healing;1.2em;sd-text-success` **Self-Healing:** Execute automatic [Fallbacks](#fallback-strategies) to recover the node.
 
+- {material-regular}`notifications;1.2em;sd-text-warning` **Alerts:** Notify the operator of specific issues.
+- {material-regular}`flash_on;1.2em;sd-text-primary` **Reflexes:** Trigger [Events](events-and-actions.md) to handle the situation.
+- {material-regular}`healing;1.2em;sd-text-success` **Self-Healing:** Execute automatic [Fallbacks](#fallback-strategies) to recover the node.
 
 ### Status Hierarchy
 
@@ -27,18 +27,17 @@ EMOS defines distinct failure levels to help you pinpoint the root cause of an i
 - <span class="sd-text-warning" style="font-weight: bold; font-size: 1.1em;">{material-regular}`warning;1.5em;sd-text-warning` ALGORITHM_FAILURE</span>
   **"I ran, but I couldn't solve it."**
   The node is healthy, but the logic failed.
-  *Examples:* Path planner couldn't find a path; Object detector found nothing; Optimization solver did not converge.
+  _Examples:_ Path planner couldn't find a path; Object detector found nothing; Optimization solver did not converge.
 
 - <span class="sd-text-danger" style="font-weight: bold; font-size: 1.1em;">{material-regular}`error;1.5em;sd-text-danger` COMPONENT_FAILURE</span>
   **"I am broken."**
   An internal crash or hardware issue occurred within this specific node.
-  *Examples:* Memory leak; Exception raised in a callback; Division by zero.
+  _Examples:_ Memory leak; Exception raised in a callback; Division by zero.
 
 - <span class="sd-text-primary" style="font-weight: bold; font-size: 1.1em;">{material-regular}`link_off;1.5em;sd-text-primary` SYSTEM_FAILURE</span>
   **"I am fine, but my inputs are broken."**
   The failure is caused by an external dependency.
-  *Examples:* Input topic is empty or stale; Network is down; Disk is full.
-
+  _Examples:_ Input topic is empty or stale; Network is down; Disk is full.
 
 ### Reporting Status
 
@@ -54,7 +53,7 @@ self.health_status.set_healthy()
 
 #### Declaring Failures
 
-When things go wrong, be specific. This helps the Fallback system decide whether to *Retry* (Algorithm), *Restart* (Component), or *Wait* (System).
+When things go wrong, be specific. This helps the Fallback system decide whether to _Retry_ (Algorithm), _Restart_ (Component), or _Wait_ (System).
 
 **Algorithm Failure:**
 
@@ -80,7 +79,6 @@ self.health_status.set_fail_component(component_names=["Camera_Driver_API"])
 self.health_status.set_fail_system(topic_names=["/camera/rgb", "/odom"])
 ```
 
-
 ### Automatic Broadcasting
 
 You do not need to manually publish the status message.
@@ -88,10 +86,9 @@ You do not need to manually publish the status message.
 EMOS automatically broadcasts the status at the start of every execution step. This ensures a consistent "Heartbeat" frequency, even if your algorithm blocks or hangs (up to the threading limits).
 
 :::{tip}
-If you need to trigger an immediate alert from a deeply nested callback or a separate thread, you *can* force a publish:
+If you need to trigger an immediate alert from a deeply nested callback or a separate thread, you _can_ force a publish:
 `self.health_status_publisher.publish(self.health_status())`
 :::
-
 
 ### Implementation Pattern
 
@@ -132,9 +129,10 @@ def _execution_step(self):
 Fallbacks are the **Self-Healing Mechanism** of an EMOS component. They define the specific set of [Actions](events-and-actions.md#actions) to execute automatically when a failure is detected in the component's Health Status.
 
 Instead of crashing or freezing when an error occurs, a Component can be configured to attempt intelligent recovery strategies:
-* {material-regular}`swap_horiz;1.2em;sd-text-warning` *Algorithm stuck?* $\rightarrow$ **Switch** to a simpler backup.
-* {material-regular}`restart_alt;1.2em;sd-text-danger` *Driver disconnected?* $\rightarrow$ **Re-initialize** the hardware.
-* {material-regular}`autorenew;1.2em;sd-text-primary` *Sensor timeout?* $\rightarrow$ **Restart** the node.
+
+- {material-regular}`swap_horiz;1.2em;sd-text-warning` _Algorithm stuck?_ $\rightarrow$ **Switch** to a simpler backup.
+- {material-regular}`restart_alt;1.2em;sd-text-danger` _Driver disconnected?_ $\rightarrow$ **Re-initialize** the hardware.
+- {material-regular}`autorenew;1.2em;sd-text-primary` _Sensor timeout?_ $\rightarrow$ **Restart** the node.
 
 ```{figure} /_static/images/diagrams/fallbacks_dark.png
 :class: dark-only
@@ -150,7 +148,6 @@ Instead of crashing or freezing when an error occurs, a Component can be configu
 The Self-Healing Loop
 ```
 
-
 ### The Recovery Hierarchy
 
 When a component reports a failure, EMOS doesn't just panic. It checks for a registered fallback strategy in a specific order of priority.
@@ -160,24 +157,22 @@ This allows you to define granular responses for different types of errors.
 - <span class="sd-text-primary" style="font-weight: bold; font-size: 1.1em;">{material-regular}`link_off;1.5em;sd-text-primary` 1. System Failure</span> `on_system_fail`
   **The Context is Broken.**
   External failures like missing input topics or disk full.
-  *Example Strategy:* Wait for data, or restart the data pipeline.
+  _Example Strategy:_ Wait for data, or restart the data pipeline.
 
 - <span class="sd-text-danger" style="font-weight: bold; font-size: 1.1em;">{material-regular}`error;1.5em;sd-text-danger` 2. Component Failure</span> `on_component_fail`
   **The Node is Broken.**
   Internal crashes or hardware disconnects.
-  *Example Strategy:* Restart the component lifecycle or re-initialize drivers.
+  _Example Strategy:_ Restart the component lifecycle or re-initialize drivers.
 
 - <span class="sd-text-warning" style="font-weight: bold; font-size: 1.1em;">{material-regular}`warning;1.5em;sd-text-warning` 3. Algorithm Failure</span> `on_algorithm_fail`
   **The Logic is Broken.**
   The code ran but couldn't solve the problem (e.g., path not found).
-  *Example Strategy:* Reconfigure parameters (looser tolerance) or switch algorithms.
+  _Example Strategy:_ Reconfigure parameters (looser tolerance) or switch algorithms.
 
 - <span class="sd-text-secondary" style="font-weight: bold; font-size: 1.1em;">{material-regular}`help_center;1.5em;sd-text-secondary` 4. Catch-All</span> `on_fail`
   **Generic Safety Net.**
   If no specific handler is found above, this fallback is executed.
-  *Example Strategy:* Log an error or stop the robot.
-
-
+  _Example Strategy:_ Log an error or stop the robot.
 
 ### Recovery Strategies
 
@@ -185,7 +180,7 @@ A Fallback isn't just a single function call. It is a robust policy defined by *
 
 #### The Persistent Retry (Single Action)
 
-*Try, try again.*
+_Try, try again._
 The system executes the action repeatedly until it returns `True` (success) or `max_retries` is reached.
 
 ```python
@@ -195,7 +190,7 @@ driver.on_component_fail(fallback=restart(component=driver), max_retries=3)
 
 #### The Escalation Ladder (List of Actions)
 
-*If at first you don't succeed, try something stronger.*
+_If at first you don't succeed, try something stronger._
 You can define a sequence of actions. If the first one fails (after its retries), the system moves to the next one.
 
 1. **Clear Costmaps** (Low cost, fast)
@@ -217,7 +212,6 @@ planner.on_algorithm_fail(
 #### The "Give Up" State
 
 If all strategies fail (all retries of all actions exhausted), the component enters the **Give Up** state and executes the `on_giveup` action. This is the "End of Line", usually used to park the robot safely or alert a human.
-
 
 ### How to Implement Fallbacks
 
@@ -279,4 +273,27 @@ class MyDriver(BaseComponent):
         if self.hw.connect():
             return True # Recovery Succeeded!
         return False    # Recovery Failed, will retry...
+```
+
+---
+
+## Process-Level Recovery
+
+The Health-Status / Fallback system above operates **inside a running component**. If a component goes further than that and the _entire process_ crashes -- a segfault in a native dependency, a Python `os._exit`, an OOM kill -- there is nothing left running to dispatch a fallback. EMOS adds a layer underneath for exactly this case.
+
+### Respawning crashed processes -- `Launcher.on_process_fail`
+
+`Launcher.on_process_fail()` enables process-level respawning for every component the launcher started in multiprocessing mode. If a component process exits with a non-zero status outside of normal shutdown, the launcher relaunches it.
+
+```python
+launcher = Launcher()
+launcher.add_pkg(components=[...], multiprocessing=True, package_name="...")
+launcher.on_process_fail(max_retries=3)   # respawn up to 3 times per component
+launcher.bringup()
+```
+
+User-initiated shutdowns (Ctrl-C, SIGTERM) do not count as failures, so this won't fight you when you stop the recipe yourself.
+
+```{tip}
+Pair `on_process_fail` with `executor_spin_timeout` (see [Launcher](launcher.md)) when running latency-sensitive callbacks -- the latter prevents a slow callback from looking like a stalled process and tripping the respawn unnecessarily.
 ```

--- a/docs/concepts/web-ui.md
+++ b/docs/concepts/web-ui.md
@@ -2,7 +2,7 @@
 
 The **Dynamic Web UI** brings an entirely new level of **system visibility**, **control**, and **ease of use** to EMOS recipes. Built with [**FastHTML**](https://www.fastht.ml/) and [**MonsterUI**](https://monsterui.answer.ai/), it **automatically generates a responsive, extensible web interface** for any EMOS recipe -- eliminating the need for manual front-end work.
 
-With zero configuration, your ROS 2 system instantly becomes a **fully monitorable and configurable web application**, complete with real-time data streaming and visual feedback.
+With zero configuration, your EMOS recipe instantly that has spawned a ROS2 based system, becomes a **fully monitorable and configurable application**, complete with real-time data streaming and visual feedback.
 
 ---
 
@@ -48,6 +48,15 @@ You can view, control, and debug every part of your ROS 2 application directly f
   </picture>
   </p>
 
+- {material-regular}`hub;1.2em;sd-text-primary` **System Graph** --
+  A draggable, resizable node-graph view of the whole running recipe: components are nodes, topics are typed edges, and **events** and **actions** are first-class graph elements with their own detail cards. Click any element to inspect it. See the [Visualizing the System Graph](../recipes/events-and-resilience/visualizing-system-graph.md) recipe for a hands-on tour.
+
+  <p align="center">
+  <picture align="center">
+    <img alt="System Graph view in the Web UI" src="https://automatikarobotics.com/docs/system_vis_ui.gif" width="90%">
+  </picture>
+  </p>
+
 - {material-regular}`build;1.2em;sd-text-primary` **Extensible Design** --
   Developers can extend the UI to support **custom message types**, **interactive widgets**, or **bespoke visualizations**.
 
@@ -59,7 +68,7 @@ The following example shows how to enable the Dynamic Web UI to automatically ge
 
 In the example below, we show how to enable the UI directly within a recipe to send and receive text messages, visualize detections, or stream live camera images from your robot -- all without writing a single line of front-end code.
 
-For a complete, real-world example, see how a similar UI is used in the VLM agent recipe from [**EmbodiedAgents**](https://automatika-robotics.github.io/embodied-agents/).
+For a complete, real-world example, see how a similar UI is used in the [VLM agent recipe](../getting-started/quickstart.md).
 
 ### Step 1 -- Define Your Topics
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,19 @@ extensions = [
     "myst_parser",
     "sphinx_sitemap",
     "sphinx_design",
+    "sphinxcontrib.mermaid",
 ]
+
+mermaid_version = "latest"
+mermaid_init_config = {
+    "startOnLoad": False,
+    "securityLevel": "loose",
+    # NOTE: keep the inner quotes single. The extension embeds this dict
+    # inside a JS template literal, which would consume backslash-escaped
+    # double quotes before JSON.parse sees them.
+    "fontFamily": "'Architects Daughter', 'Caveat', system-ui, sans-serif",
+    "flowchart": {"curve": "basis"},
+}
 
 # -- autodoc2: all three packages in one build
 autodoc2_packages = [
@@ -146,6 +158,8 @@ LLMS_TXT_SELECTION = [
     # Intelligence Layer (EmbodiedAgents) -- components, clients, models
     "intelligence/overview.md",
     "intelligence/ai-components.md",
+    "intelligence/cortex.md",
+    "intelligence/memory.md",
     "intelligence/clients.md",
     "intelligence/models.md",
     # Navigation Layer (Kompass) -- robot config, planning, control
@@ -165,6 +179,9 @@ LLMS_TXT_SELECTION = [
     "recipes/foundation/semantic-routing.md",
     "recipes/foundation/complete-agent.md",
     # Planning & Manipulation Recipes
+    "recipes/planning-and-manipulation/cortex-agent.md",
+    "recipes/planning-and-manipulation/cortex-memory.md",
+    "recipes/planning-and-manipulation/cortex-navigation.md",
     "recipes/planning-and-manipulation/planning-models.md",
     "recipes/planning-and-manipulation/vla-manipulation.md",
     "recipes/planning-and-manipulation/event-driven-vla.md",
@@ -179,6 +196,8 @@ LLMS_TXT_SELECTION = [
     "recipes/events-and-resilience/multiprocessing.md",
     "recipes/events-and-resilience/fallback-recipes.md",
     "recipes/events-and-resilience/event-driven-cognition.md",
+    "recipes/events-and-resilience/visualizing-system-graph.md",
+    "recipes/events-and-resilience/internal-state-events.md",
     "recipes/events-and-resilience/external-reflexes.md",
     "recipes/events-and-resilience/cross-component-events.md",
     "recipes/events-and-resilience/composed-events.md",
@@ -227,16 +246,20 @@ def generate_llms_txt(app, exception):
         "GenericHTTPClient, LeRobotClient, etc.) with a model wrapper. Clients are "
         "interchangeable -- swap inference backends without changing component logic.\n"
         "3. **Build Components** -- Instantiate components (LLM, VLM, VLA, SpeechToText, "
-        "TextToSpeech, Vision, MapEncoding, SemanticRouter) with inputs, outputs, and a "
-        "model_client. Set `trigger` to control when the component executes.\n"
+        "TextToSpeech, Vision, Memory, Cortex, SemanticRouter) with inputs, outputs, and a "
+        "model_client. Set `trigger` to control when the component executes. Use `Memory` "
+        "for spatio-temporal memory and `Cortex` as an agentic harness that auto-discovers "
+        "the rest of the graph as LLM tools.\n"
         "4. **Wire Navigation** -- For mobile robots, configure a `RobotConfig` and "
         "instantiate Kompass components (Planner, Controller, DriveManager) with appropriate "
         "algorithms (DWA, PurePursuit, etc.).\n"
-        "5. **Add Events & Fallbacks** -- Use `on_algorithm_fail()`, `on_component_fail()`, "
-        "and custom event/action pairs for runtime adaptivity. Events can trigger model swaps, "
-        "component restarts, or arbitrary callbacks.\n"
-        "6. **Launch** -- Use `Launcher()` to add component packages and call `bringup()`. "
-        "For production, run components in separate processes via `Launcher(multiprocessing=True)`.\n\n"
+        "5. **Add Events & Fallbacks** -- Use `on_fail()` per component for restart-style "
+        "recovery, `launcher.on_process_fail()` for process-level crash recovery, and custom "
+        "event/action pairs for runtime adaptivity. Events can trigger model swaps, component "
+        "restarts, or arbitrary callbacks.\n"
+        "6. **Launch** -- Use `Launcher()` to add component packages with "
+        "`launcher.add_pkg(components=[...], multiprocessing=True)` and call `bringup()`. "
+        "The `multiprocessing` flag goes on `add_pkg`, not on the Launcher constructor.\n\n"
         "The documentation below is ordered as a curriculum: architecture first, then "
         "components and APIs, then example recipes of increasing complexity.\n\n"
         "---\n\n"

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,9 @@ recipes/foundation/complete-agent
 :caption: Planning & Manipulation
 
 recipes/planning-and-manipulation/index
+recipes/planning-and-manipulation/cortex-agent
+recipes/planning-and-manipulation/cortex-memory
+recipes/planning-and-manipulation/cortex-navigation
 recipes/planning-and-manipulation/planning-models
 recipes/planning-and-manipulation/vla-manipulation
 recipes/planning-and-manipulation/event-driven-vla
@@ -73,6 +76,8 @@ recipes/events-and-resilience/index
 recipes/events-and-resilience/multiprocessing
 recipes/events-and-resilience/fallback-recipes
 recipes/events-and-resilience/event-driven-cognition
+recipes/events-and-resilience/visualizing-system-graph
+recipes/events-and-resilience/internal-state-events
 recipes/events-and-resilience/external-reflexes
 recipes/events-and-resilience/cross-component-events
 recipes/events-and-resilience/composed-events
@@ -99,6 +104,8 @@ concepts/web-ui
 
 intelligence/overview
 intelligence/ai-components
+intelligence/cortex
+intelligence/memory
 intelligence/clients
 intelligence/models
 ```

--- a/docs/intelligence/ai-components.md
+++ b/docs/intelligence/ai-components.md
@@ -2,6 +2,8 @@
 
 A **Component** is the primary execution unit in EmbodiedAgents, the EMOS intelligence framework. Components represent functional behaviors -- for example, the ability to process text, understand images, or synthesize speech. Components can be combined arbitrarily to create more complex systems such as multi-modal agents with perception-action loops.
 
+Most EmbodiedAgents components are **capabilities** -- a single thing the robot can do. LLM, VLM, VLA, Vision, SpeechToText, TextToSpeech, SemanticRouter, VideoMessageMaker each wrap a particular modality or model surface; [Memory](memory.md) is a capability too, giving the robot a graph-backed spatio-temporal record of what it has seen and felt. [Cortex](cortex.md) is the one component that doesn't sit in that family: it's a high-level planner-executor that *uses* the capabilities, turning natural-language goals into ordered calls against the available component capabilities.
+
 ```{note}
 To learn more about the internal structure and lifecycle behavior of components, check out the concept [here](../concepts/components.md).
 ```
@@ -30,10 +32,13 @@ EmbodiedAgents provides a suite of ready-to-use components. These can be compose
   - Converts spoken audio into text using speech-to-text models (e.g., Whisper). Suitable for voice command recognition. It also implements small on-board models for Voice Activity Detection (VAD) and Wakeword recognition, using audio capture devices onboard the robot. Supports built-in local STT for on-device transcription.
 
 * - **TextToSpeech**
-  - Synthesizes audio from text using TTS models (e.g., SpeechT5, Bark). Output audio can be played using the robot's speakers or published to a topic. Implements `say(text)` and `stop_playback` functions to play/stop audio based on events from other components or the environment. Supports built-in local TTS for on-device speech synthesis.
+  - Synthesizes audio from text using HuggingFace Transformers TTS models (Bark, VITS, SpeechT5, SeamlessM4T, etc.) via the unified `TransformersTTS` wrapper. Output audio can be played using the robot's speakers or published to a topic. Implements `say(text)` and `stop_playback` functions to play/stop audio based on events from other components or the environment. Supports built-in local TTS for on-device speech synthesis.
 
-* - **MapEncoding**
-  - Provides a spatio-temporal working memory by converting semantic outputs (e.g., from MLLMs or Vision) into a structured map representation. Uses robot localization data and output topics from other components to store information in a vector DB.
+* - **Memory**
+  - Provides a graph-backed spatio-temporal memory powered by [eMEM](https://github.com/automatika-robotics/emem). Encodes perception layers (e.g. detections, scene captions) and interoception layers (e.g. battery, internal flags) into an episodic, entity-aware graph and exposes ten retrieval tools as component actions. Replaces the deprecated **MapEncoding** -- see the dedicated [Memory page](memory.md).
+
+* - **Cortex**
+  - The agentic core. An AI-powered planner-executor that inspects the rest of the recipe, decomposes a natural-language goal into a sequence of component-action calls, and runs them while monitoring the outputs. See [Cortex](cortex.md).
 
 * - **SemanticRouter**
   - Routes information between topics based on semantic content and predefined routing rules. Uses a vector DB for semantic matching or an LLM for decision-making. This allows for creating complex graphs of components where a single input source can trigger different information processing pathways.

--- a/docs/intelligence/cortex.md
+++ b/docs/intelligence/cortex.md
@@ -165,7 +165,7 @@ Cortex always runs as a ROS2 **action server** -- you don't configure `run_type`
 
 ## Cortex is also the Monitor
 
-When the launcher detects a Cortex component in the recipe, it is **also used as the Monitor** -- the central node that hosts events and actions, tracks every component's health, manages lifecycle transitions, and coordinates fallbacks. Practical implications:
+When the launcher detects a Cortex component in the recipe, it is **also used as the Monitor** -- the central node that hosts events and actions, tracks every component's health, manages lifecycle transitions, and coordinates fallbacks.
 
 This is why Cortex needs no list of components to monitor -- the launcher feeds it the full graph.
 
@@ -202,11 +202,12 @@ Setting `db_client` on Cortex enables retrieval-augmented planning. Before each 
 
 ```python
 from agents.clients import ChromaClient
+from agents.vectordbs import ChromaDB
 
 cortex = Cortex(
     output=cortex_output,
     model_client=planner_client,
-    db_client=ChromaClient(host="localhost", port=8000),
+    db_client=ChromaClient(db=ChromaDB(), host="localhost", port=8000),
     config=CortexConfig(
         enable_rag=True,
         collection_name="building_layout",

--- a/docs/intelligence/cortex.md
+++ b/docs/intelligence/cortex.md
@@ -1,0 +1,238 @@
+# Cortex
+
+**The agentic harness for embodied intelligence.** Cortex is the EmbodiedAgents component that turns the rest of your recipe into an agent: it discovers every component you added, registers their methods as LLM tools, and lets the user address the whole system in plain language. If [Claude Code](https://claude.com/claude-code) is an agentic harness for software engineering, Cortex is its analogue for robots -- the same primitives (read the environment, plan, dispatch tools, watch results, replan) applied to a physical system.
+
+A recipe with a Cortex stops being a programmed pipeline and starts being something you talk to.
+
+```{seealso}
+For the introductory walkthrough, start with [Cortex: The Agentic Harness](../recipes/planning-and-manipulation/cortex-agent.md). For Cortex paired with spatio-temporal memory, see [Memory and Cortex](../recipes/planning-and-manipulation/cortex-memory.md). For the full multi-system showcase that adds navigation on top, see [Cortex Driving the Full Stack](../recipes/planning-and-manipulation/cortex-navigation.md).
+```
+
+---
+
+## What Cortex replaces
+
+A non-Cortex EMOS recipe earns each capability by hand-wiring it: a vision component publishes detections, an event matches the detection class, a fallback restarts the camera if it stalls, a separate LLM component parses the user's input into structured goals, and so on. Every link is yours to author and maintain.
+
+A Cortex recipe is the same components -- minus the wiring. Cortex inspects the running graph at activation, registers every available capability as a callable tool, and accepts the user's intent directly:
+
+| Without Cortex                                                           | With Cortex                                                                                                                   |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| One event-action pair per behaviour, hand-wired in the recipe.           | The recipe has no behavioural wiring. Cortex plans the behaviour at runtime from the user's goal.                             |
+| Each capability needs an explicit handler that knows when to trigger it. | Each capability is a `@component_action` on its component. Cortex discovers them all on activation.                           |
+| User input is parsed by a bespoke LLM step into a typed goal.            | User input is a free-form string sent to Cortex's main action server.                                                         |
+| Fallback policies wired per component.                                   | Cortex's confirmation step (EXECUTE / SKIP / ABORT / CONTINUE) handles per-step recovery; replan handles plan-level recovery. |
+| You write the orchestration code.                                        | You write the components. Cortex writes the recipe.                                                                           |
+
+---
+
+## How it works
+
+Cortex runs a **two-phase loop** for every task.
+
+### Phase 1 -- Planning (multi-step)
+
+The planner LLM is handed two tool sets:
+
+- **Planning tools** -- read-only research tools. The built-in `inspect_component` plus any `@component_action(phase=ActionPhase.PLANNING)` methods on managed components.
+- **Execution tools** -- everything that _does_ something. Custom `Action` objects, `@component_action(phase=ActionPhase.EXECUTION)` methods, action-server goal tools, service-request tools, and the built-in `update_parameter`.
+
+On each iteration, the LLM may:
+
+1. Call **planning tools** to gather information -- inspect a component, query memory, look up a fact in a vector DB. Results are appended to the conversation and the loop continues.
+2. Call **execution tools** -- this commits a plan as an ordered list of steps, and the loop ends.
+3. Respond with **text only** -- no actions needed; the text is published on `output` and the task is done.
+
+Up to `max_planning_steps` iterations of research are allowed before the planner must commit. Plans longer than `max_execution_steps` are truncated.
+
+### Phase 2 -- Execution with confirmation
+
+Each step is dispatched in turn. **Before** each one, a brief confirmation LLM call returns one of:
+
+| Decision   | Effect                                                                                                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EXECUTE`  | Run the next step. The confirmation may also return a tool call with **resolved arguments** -- e.g. binding a placeholder like `<output from step 1>` to the actual return value of step 1. |
+| `SKIP`     | Skip this step and continue.                                                                                                                                                                |
+| `ABORT`    | Abort the entire plan.                                                                                                                                                                      |
+| `CONTINUE` | Wait for in-flight async actions to finish before deciding.                                                                                                                                 |
+
+`CONTINUE` is the key to long-horizon tasks. When Cortex dispatches an action goal (e.g. to a Planner action server), it tracks the client in `_active_action_clients` and the confirmation prompt includes the action's live feedback. The LLM can `CONTINUE` to wait, watch how the goal is progressing, and only `EXECUTE` the next step when the action reports SUCCEEDED.
+
+### Replan on incomplete execution
+
+If the plan exits before reaching its terminal step (because a step `ABORT`-ed, or because the executor ran out of steps with goals still in flight), Cortex composes a fresh plan from where it left off, with the partial-execution results fed back into the planning conversation. Long-horizon tasks ("patrol until you see a person") express naturally: each replan is one outer iteration.
+
+---
+
+## What gets auto-discovered
+
+When the launcher activates Cortex, it walks every component in the recipe and registers tools for everything it finds. **You write none of this registration -- it happens once on activation.**
+
+### Built-in tools
+
+| Tool                                                 | Phase     | Purpose                                                                                                                                                                                                         |
+| ---------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inspect_component(component)`                       | Planning  | Returns the component's full structure: input/output topics, config, additional model clients, and the actions Cortex has registered for it. The planner uses this to discover topic names and ground its plan. |
+| `update_parameter(component, param_name, new_value)` | Execution | Re-tunes any config parameter on any managed component at runtime. The LLM can lower `Vision.threshold` mid-task or flip `Controller.direct_sensor` if the mission demands it.                                  |
+
+### Component capabilities
+
+For every managed component, Cortex discovers:
+
+- **`@component_action` methods** -- registered as namespaced tools `{component_name}.{method_name}` with the OpenAI-format description from the decorator. Classified as planning, execution, or both via the `phase=` argument:
+
+  ```python
+  from agents.ros import ActionPhase, component_action
+
+  class MyComponent(BaseComponent):
+      @component_action(description={...}, phase=ActionPhase.PLANNING)
+      def look_up_thing(self): ...    # planner-only research tool
+
+      @component_action(description={...}, phase=ActionPhase.EXECUTION)
+      def grasp(self): ...             # executor-only state-changing action
+
+      @component_action(description={...}, phase=ActionPhase.BOTH)
+      def describe_scene(self): ...    # both phases
+  ```
+
+  Bare `@component_action` defaults to `ActionPhase.EXECUTION`, preserving historical behaviour.
+
+- **`@component_fallback` methods** -- registered the same way, exposed as recovery tools the planner can fall back to.
+
+- **Additional ROS services** (returned by `get_ros_entrypoints()["services"]`) -- registered as `send_request_to_{name}` execution tools. The request type is auto-translated to JSON properties so the LLM fills request fields directly; Cortex constructs the message and sends it.
+
+- **Additional ROS action servers** (returned by `get_ros_entrypoints()["actions"]`) -- registered as `send_goal_to_{name}` execution tools, with the goal type auto-translated the same way. The Controller's `track_vision_target` action server is auto-discovered this way, for instance.
+
+- **The component's main action server** (when `run_type = "ActionServer"`) -- registered the same way. Setting `Planner.run_type = "ActionServer"` is what makes the Planner's main goal callable as an LLM tool.
+
+### Custom actions
+
+Capabilities that don't naturally live on a managed component (a peripheral toggle, a database call, an external API hit) can be passed in via `actions=[...]`:
+
+```python
+from agents.ros import Action
+
+cortex = Cortex(
+    actions=[
+        Action(method=toggle_led, description="Toggle the robot's LED on or off."),
+        Action(method=query_inventory, description="Look up the current item inventory."),
+    ],
+    ...,
+)
+```
+
+Each `Action` must carry a description -- it's what the planner sees when deciding whether to call the tool.
+
+---
+
+## Public API
+
+```python
+from agents.components import Cortex
+from agents.config import CortexConfig
+from agents.ros import Action, Topic, Launcher
+```
+
+```python
+cortex_output = Topic(name="cortex_output", msg_type="StreamingString")
+
+cortex = Cortex(
+    actions=[Action(method=toggle_led, description="...")],
+    output=cortex_output,
+    model_client=planner_client,
+    db_client=chroma_client,                          # optional: enables RAG context
+    config=CortexConfig(
+        max_planning_steps=5,
+        max_execution_steps=15,
+        enable_rag=True,
+        collection_name="robot_manual",
+    ),
+    component_name="cortex",
+)
+```
+
+| Argument       | Purpose                                                                                                                                                                                                                        |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `actions`      | Custom `Action` objects to expose as execution tools. Optional.                                                                                                                                                                |
+| `output`       | A topic Cortex publishes to when the goal can be answered with text alone (no plan needed). Wire it into TTS to give the robot a voice for its own thoughts, or into the UI to render replies inline.                          |
+| `model_client` | The LLM client used for planning and confirmation. Optional if `enable_local_model=True`.                                                                                                                                      |
+| `db_client`    | Optional vector-DB client (e.g. `ChromaClient`). When set, Cortex queries it before each planning call and injects the result as RAG context. Used for domain knowledge: robot manuals, environment maps, prior conversations. |
+| `config`       | A `CortexConfig`. Most-tuned fields are `max_planning_steps`, `max_execution_steps`, `enable_local_model`, `enable_rag`, `collection_name`, and `confirmation_temperature`.                                                    |
+
+Cortex always runs as a ROS2 **action server** -- you don't configure `run_type`. Its action type is `VisionLanguageAction` and the goal field is `task: string`.
+
+---
+
+## Cortex is also the Monitor
+
+When the launcher detects a Cortex component in the recipe, it is **also used as the Monitor** -- the central node that hosts events and actions, tracks every component's health, manages lifecycle transitions, and coordinates fallbacks. Practical implications:
+
+This is why Cortex needs no list of components to monitor -- the launcher feeds it the full graph.
+
+---
+
+## Memory-aware planning
+
+When a [Memory](memory.md) component is in the recipe, Cortex's planning prompt is **automatically augmented** on activation. The augmentation:
+
+- Lists Memory's perception-retrieval tools (`semantic_search`, `locate`, `recall`, ...) and its body-status tool, so the planner knows the difference between perception and interoception layers.
+- Pre-computes Memory's `inspect_component` output and embeds it in the system prompt, so the planner already knows the layer names without having to spend a planning step researching.
+- Adds a **task classification** step: every incoming task is assigned to (A) PERCEPTION QUERY, (B) BODY QUERY, or (C) ACTION TASK. Each class has a specific protocol (perception queries don't open episodes; action tasks always wrap themselves in `start_episode` / `end_episode` and check `body_status` first).
+- Body-status checks become **mandatory** for action tasks, so a Cortex with an interoception layer (battery, fault flags) might refuse missions when the readings indicate a problem rather than running them and discovering the issue mid-flight.
+
+No extra wiring. Drop a Memory component into the launcher and the augmentation kicks in. See [Memory and Cortex](../recipes/planning-and-manipulation/cortex-memory.md) for the full pattern.
+
+---
+
+## Observability
+
+Cortex publishes feedback on its action server during execution. Each plan step generates a feedback line carrying:
+
+- Step number and tool name.
+- Whether the step is being EXECUTE-d, SKIP-ped, ABORT-ed, or whether confirmation said CONTINUE.
+- Live status of any action goals in flight (running for _N_ seconds, latest feedback, stall warnings).
+
+The launcher's Web UI shows these feedback lines in the **main logging card** alongside the components' own logs, so the operator sees the agent's reasoning trace and the Planner's path-tracking feedback side by side.
+
+---
+
+## RAG context
+
+Setting `db_client` on Cortex enables retrieval-augmented planning. Before each planning call, Cortex queries the configured vector DB with the user's task and prepends the results to the planning prompt:
+
+```python
+from agents.clients import ChromaClient
+
+cortex = Cortex(
+    output=cortex_output,
+    model_client=planner_client,
+    db_client=ChromaClient(host="localhost", port=8000),
+    config=CortexConfig(
+        enable_rag=True,
+        collection_name="building_layout",
+        n_results=5,
+        add_metadata=True,
+    ),
+    component_name="cortex",
+)
+
+# Populate the DB with domain knowledge ahead of time:
+cortex.add_documents(
+    ids=["floor1", "floor2"],
+    metadatas=[{"floor": 1}, {"floor": 2}],
+    documents=[
+        "Floor 1 contains the kitchen, dining room, and main entrance.",
+        "Floor 2 contains the bedrooms and the office.",
+    ],
+)
+```
+
+Use this for static facts the planner shouldn't have to learn from the live recipe -- robot manuals, environment maps, prior conversation transcripts. For _dynamic_ facts the robot acquires at runtime, use [Memory](memory.md).
+
+---
+
+## Recipes
+
+- {doc}`Cortex: The Agentic Harness <../recipes/planning-and-manipulation/cortex-agent>` -- introductory tutorial. Vision + VLM + TTS + a custom action, all addressed in plain English with no orchestration code.
+- {doc}`Cortex Driving the Full Stack <../recipes/planning-and-manipulation/cortex-navigation>` -- the showcase. Cortex orchestrates a Kompass navigation stack, Vision, VLM, Memory, and TTS to handle compound natural-language goals.
+- {doc}`Memory and Cortex <../recipes/planning-and-manipulation/cortex-memory>` -- spatio-temporal memory wired into a Cortex planner; perception layers + interoception layers; episode-based consolidation; cross-session persistence.

--- a/docs/intelligence/memory.md
+++ b/docs/intelligence/memory.md
@@ -134,7 +134,7 @@ scene      = Topic(name="scene_description", msg_type="String")
 battery    = Topic(name="/battery_level", msg_type="Float32")
 
 # Perception layers
-detections_layer = MemLayer(subscribes_to=detections, temporal_change=True)
+detections_layer = MemLayer(subscribes_to=detections)
 scene_layer      = MemLayer(subscribes_to=scene)
 
 # Interoception layer
@@ -144,7 +144,6 @@ battery_layer    = MemLayer(subscribes_to=battery, is_internal_state=True)
 | Field | Meaning |
 |---|---|
 | `subscribes_to` | The topic to ingest from. |
-| `temporal_change` | If `True`, observations on the same spatial position are timestamped and stored as a sequence. Useful for objects that move or reappear. |
 | `is_internal_state` | If `True`, observations are routed through `add_body_state` -- they're invisible to perception retrieval tools and surface only through the dedicated `body_status` tool. Used for interoception. |
 
 `MapLayer` is preserved as a backwards-compatible alias of `MemLayer`.

--- a/docs/intelligence/memory.md
+++ b/docs/intelligence/memory.md
@@ -1,0 +1,264 @@
+# Memory
+
+**The first memory system for embodied agents built on neuroscience principles.** Memory is the EmbodiedAgents component that gives a robot a persistent, queryable sense of *place* and *history*. It is built on top of [eMEM](https://github.com/automatika-robotics/emem) -- a hybrid graph-based spatio-temporal memory designed specifically for situated agents. The core problem eMEM solves is the false dichotomy that has dominated robot memory until now:
+
+> Vector databases discard spatial structure. Metric maps discard semantics. **eMEM unifies both.**
+
+Memory accumulates a typed graph of everything the robot perceives -- detections, scene descriptions, sensor strings, internal-state readings -- indexed simultaneously by **meaning** (HNSW), **location** (R-tree), and **time** (SQLite indexes). Episodes group observations into task spans. Consolidation collapses old observations into searchable gists. Entity nodes track persistent objects across episodes via semantic-spatial merging. And **interoception** -- the robot's own internal state -- is a first-class memory dimension alongside world observations, not a separate metrics pipeline.
+
+```{important}
+`Memory` is the supported successor to **MapEncoding**, deprecated since EmbodiedAgents 0.7.1. The two are not API-compatible: Memory replaces a flat vector-DB store with episodic consolidation, entity tracking, and an interoception surface. See [Migration](#migration-from-mapencoding) below.
+```
+
+```{seealso}
+For a hands-on intro to Memory by itself, see [Spatio-Temporal Memory](../recipes/foundation/semantic-map.md). For the deep pairing with Cortex (the agentic harness), see [Memory and Cortex](../recipes/planning-and-manipulation/cortex-memory.md). For eMEM internals, see the [eMEM repository](https://github.com/automatika-robotics/emem).
+```
+
+```{admonition} Installation
+:class: note
+
+`Memory` depends on the [eMEM](https://github.com/automatika-robotics/emem) package and raises `ImportError` at construction if it isn't available. Install it into the same environment as the EMOS launcher: `pip install emem`.
+```
+
+---
+
+## Why it works
+
+eMEM's design is grounded in how humans and other animals actually structure memory.
+
+- {material-regular}`schema;1.2em;sd-text-primary` **Tiered consolidation** -- observations flow `working → short-term → long-term → archived`, mirroring the consolidation hierarchy seen in mammalian memory. Recent experience stays raw and queryable; older experience compresses into gists; ancient experience is archived (raw text removed, gist preserved). This bounds storage growth without losing the *meaning* of past activity.
+
+- {material-regular}`account_tree;1.2em;sd-text-primary` **Episodic structure** -- experience is grouped into named episodes that can nest hierarchically (`SUBTASK_OF`) and chain temporally (`FOLLOWS`). When an episode ends, its observations are clustered, summarised by an LLM into a *gist* that preserves the semantic content, the spatial centroid, and the time span -- and the raw observations are archived.
+
+- {material-regular}`hub;1.2em;sd-text-primary` **Entity persistence** -- detections of the same object across multiple episodes are auto-merged into a single `EntityNode` via semantic similarity (cosine) *and* spatial proximity (range threshold). The first time the robot sees "the red chair near the door", it's a new entity; the second time, it's recognised as the same one. `COOCCURS_WITH` edges capture which entities tend to be observed together.
+
+- {material-regular}`favorite;1.2em;sd-text-primary` **Interoception as memory** -- internal body state (battery, temperature, joint health, fault flags) is stored in the same graph as world observations, not in a separate telemetry stream. This is what lets a query like *"what was happening when the battery dropped?"* work -- the spatial-temporal-interoceptive associations emerge naturally because everything lives in the same graph.
+
+The whole stack runs **fully embedded** -- SQLite, hnswlib, and Rtree, with zero external services. A single `.db` file plus a `.hnsw.bin` file *is* the entire memory state. Reboot the robot, point it at the same files, and the prior session is remembered.
+
+---
+
+## Architecture at a glance
+
+```
+                    +-----------------+
+                    |  Memory         |  (EmbodiedAgents component)
+                    +--------+--------+
+                             |  delegates to
+                    +--------v--------+
+                    | SpatioTemporal  |
+                    |     Memory      |  (eMEM facade)
+                    +--------+--------+
+                             |
+              +--------------+--------------+
+              |              |              |
+     +--------v--+   +-------v-----+  +-----v------+
+     |  Working   |  |   Memory    |  | Consolida- |
+     |  Memory    |  |   Tools     |  | tion       |
+     |  (buffer)  |  | (10 tools)  |  | Engine     |
+     +--------+---+  +------+------+  +----+-------+
+              |              |              |
+              +--------------+--------------+
+                             |
+                    +--------v--------+
+                    |   MemoryStore   |
+                    +--------+--------+
+                             |
+              +--------------+--------------+
+              |              |              |
+        +-----v----+   +-----v-----+  +-----v----+
+        |  SQLite   |  |  hnswlib  |  |  R-tree  |
+        | (nodes,   |  | (vector   |  | (spatial |
+        |  edges,   |  |  search)  |  |  index)  |
+        |  tiers)   |  |           |  |          |
+        +-----------+  +-----------+  +----------+
+```
+
+Three complementary indexes, one shared graph.
+
+### The graph
+
+Four node types and six edge types compose the memory graph:
+
+**Nodes**
+
+| Node | Carries |
+|---|---|
+| `ObservationNode` | A single perception event: text, coordinates, timestamp, layer, source_type (`perception` or `interoception`), confidence. |
+| `EpisodeNode` | A named task / activity span grouping related observations. |
+| `GistNode` | A consolidated summary of multiple observations, with spatial extent and time range. Survives archival of the raw observations. |
+| `EntityNode` | A persistent tracked object / landmark (auto-merged across episodes by similarity + spatial proximity). |
+
+**Edges**
+
+| Edge | Meaning |
+|---|---|
+| `BELONGS_TO` | Observation → Episode |
+| `FOLLOWS` | Episode → Episode (temporal sequence) |
+| `SUBTASK_OF` | Episode → Episode (hierarchical nesting) |
+| `SUMMARIZES` | Gist → Observation(s) |
+| `OBSERVED_IN` | Entity → Observation |
+| `COOCCURS_WITH` | Entity ↔ Entity |
+
+### Tiers
+
+```
+ working  →  short_term  →  long_term  →  archived
+ (buffer)    (in store)     (promoted)    (text dropped,
+                                           gist remains)
+```
+
+When an episode ends, eMEM consolidates its observations into a gist and archives them. For non-episodic streams that age past `consolidation_window`, time-window consolidation uses **DBSCAN** to spatially cluster old observations before summarising each cluster.
+
+### Unified search
+
+`semantic_search` queries observations and gists through a single HNSW lookup. After consolidation, knowledge isn't lost -- it's compressed into gists that remain searchable alongside recent observations.
+
+---
+
+## Public API
+
+```python
+from agents.components import Memory
+from agents.config import MemoryConfig
+from agents.ros import MemLayer, Topic
+```
+
+### Layers
+
+A `MemLayer` is the smallest unit of input. Each layer subscribes to one topic; the topic's UI string representation is what gets stored.
+
+```python
+detections = Topic(name="detections", msg_type="Detections")
+scene      = Topic(name="scene_description", msg_type="String")
+battery    = Topic(name="/battery_level", msg_type="Float32")
+
+# Perception layers
+detections_layer = MemLayer(subscribes_to=detections, temporal_change=True)
+scene_layer      = MemLayer(subscribes_to=scene)
+
+# Interoception layer
+battery_layer    = MemLayer(subscribes_to=battery, is_internal_state=True)
+```
+
+| Field | Meaning |
+|---|---|
+| `subscribes_to` | The topic to ingest from. |
+| `temporal_change` | If `True`, observations on the same spatial position are timestamped and stored as a sequence. Useful for objects that move or reappear. |
+| `is_internal_state` | If `True`, observations are routed through `add_body_state` -- they're invisible to perception retrieval tools and surface only through the dedicated `body_status` tool. Used for interoception. |
+
+`MapLayer` is preserved as a backwards-compatible alias of `MemLayer`.
+
+### Construction
+
+```python
+position = Topic(name="/odom", msg_type="Odometry")
+
+memory = Memory(
+    layers=[detections_layer, scene_layer, battery_layer],
+    position=position,
+    model_client=vlm_client,             # used for episode-consolidation summaries + entity extraction
+    embedding_client=embedding_client,   # used for vector indexing
+    config=MemoryConfig(db_path="/tmp/robot_memory.db"),
+    trigger=10.0,                        # flush layer data every 10s
+    component_name="memory",
+)
+```
+
+| Argument | Purpose |
+|---|---|
+| `layers` | One `MemLayer` per perception or interoception topic. |
+| `position` | An Odometry topic. Memory tags every observation with the robot's current `(x, y, z)` so spatial queries work. |
+| `model_client` | Optional. Drives summarisation during episode consolidation and entity extraction. Without it, consolidation falls back to plain text concatenation. |
+| `embedding_client` | Optional. Drives vector indexing (e.g. an Ollama client serving an embedding model). Without it, falls back to `sentence-transformers`. |
+| `config` | A `MemoryConfig` -- see below. |
+| `trigger` | When to flush observations to the working buffer. A topic, list of topics, frequency in Hz, or `Event`. |
+
+### Configuration highlights
+
+`MemoryConfig` exposes ~20 fields covering storage, consolidation, entity merging, and HNSW index tuning. The most reached-for ones in everyday recipes:
+
+| Field | Default | Controls |
+|---|---|---|
+| `db_path` | `"memory.db"` | eMEM SQLite database path. The whole memory state lives in this file. |
+| `auto_store` | `True` | Flush observations on every execution step. Set `False` to require explicit `store` calls. |
+| `working_memory_size` | `50` | Buffer size before older observations are dropped. |
+| `flush_interval` / `flush_batch_size` | `2.0s` / `5` | How aggressively the buffer is persisted. |
+| `consolidation_window` | `1800.0s` | Maximum gap between observations in the same consolidation chunk. |
+| `consolidation_spatial_eps` | `3.0m` | DBSCAN epsilon for time-window consolidation. |
+| `archive_after_seconds` | `3600.0s` | When raw observation text is dropped; the gist remains searchable. |
+| `entity_similarity_threshold` | `0.85` | Cosine threshold for merging a new detection with a known entity. |
+| `entity_spatial_radius` | `5.0m` | Spatial radius for the same merge. |
+| `recency_weight` | `0.0` | Boost recent observations in semantic search. `0.0` for pure semantic ordering. |
+
+---
+
+## Retrieval surface (10 tools)
+
+Memory exposes ten retrieval tools, all decorated as `@component_action`. Nine are `phase=ActionPhase.PLANNING` (Cortex consumes them while *building* a plan); `body_status` is `ActionPhase.BOTH` because the executor may also need it at runtime.
+
+| Tool | Purpose |
+|---|---|
+| `semantic_search` | Find observations by meaning. Queries observations *and* gists in a single HNSW lookup. |
+| `spatial_query` | Find observations within a radius of a point. R-tree backed. |
+| `temporal_query` | Find observations in a time range. Accepts relative strings like `"-10m"`. |
+| `episode_summary` | Get the consolidated summary of one or more episodes. |
+| `get_current_context` | Situational awareness -- nearby objects, area summaries, recent activity, latest body status. |
+| `search_gists` | Search consolidated long-term memory only (faster than full semantic search). |
+| `entity_query` | Find known entities by name, type, or location. |
+| `locate` | Resolve a concept to a spatial position (returns centroid + radius from the entity graph). |
+| `recall` | Cross-layer recall -- everything known about a concept across observations, gists, and entities. |
+| `body_status` | Latest interoception readings, optionally filtered by layer. |
+
+Two write-side actions are exposed as well:
+
+- `store_specific_memory` (execution) -- write an arbitrary string into memory at runtime, e.g. for runtime annotations Cortex wants to preserve.
+- `start_episode` / `end_episode` (execution) -- bracket episodes manually instead of relying on time-based consolidation.
+
+When a `Memory` component is in the recipe, [Cortex](cortex.md) auto-discovers all of these and **augments its planning prompt** with detailed task-classification guidance (PERCEPTION QUERY vs BODY QUERY vs ACTION TASK) and instructions for episode wrapping. No tool registration is required.
+
+### Registering tools on a plain LLM
+
+If you want Memory's tools without Cortex (e.g. to give a plain `LLM` component tool-calling access for natural-language Q&A), use `register_tools_on`:
+
+```python
+memory.register_tools_on(llm, send_tool_response_to_model=True)
+# Or register a subset:
+memory.register_tools_on(llm, tools=["semantic_search", "locate", "get_current_context"])
+```
+
+---
+
+## Persistence
+
+The entire memory state lives in two files: the SQLite DB at `db_path` and an HNSW index file alongside it. **Reboot the robot, point the next session at the same paths, and the agent picks up where it left off.** Episodes from yesterday are still in the graph; entities are still merged; gists are still searchable. Cross-session continuity is the default, not a feature you opt into.
+
+This is what makes eMEM-on-Cortex behave as a cognitive system rather than a session-scoped vector DB.
+
+---
+
+## Migration from MapEncoding
+
+| MapEncoding | Memory |
+|---|---|
+| `MapEncoding` component | `Memory` component |
+| `MapLayer` | `MemLayer` (alias preserved) |
+| Flat vector DB (Chroma) | Graph + episodic + entity index, eMEM-backed |
+| `db_client=ChromaClient(...)` | `model_client=...`, `embedding_client=...` |
+| `map_topic=OccupancyGrid` (required) | None -- Memory uses real-world coords from Odometry directly |
+| `MapConfig(map_name=…)` | `MemoryConfig(db_path=…)` |
+| Free-form text retrieval via tool calling | Ten typed retrieval tools auto-registered with Cortex |
+| No interoception | `is_internal_state=True` on a layer surfaces it via `body_status` |
+| No episode structure | `start_episode` / `end_episode`, hierarchical nesting, automatic consolidation |
+| No entity tracking | Persistent `EntityNode` with semantic-spatial auto-merge |
+| Session-scoped | Cross-session persistent (single `.db` file) |
+
+Existing recipes built on `MapEncoding` still load with a deprecation warning. New recipes should use `Memory`.
+
+---
+
+## Recipes
+
+- {doc}`Spatio-Temporal Memory <../recipes/foundation/semantic-map>` -- introductory recipe. Memory built from a Vision component's detections and an MLLM's introspective answers, no Cortex on top.
+- {doc}`Memory and Cortex <../recipes/planning-and-manipulation/cortex-memory>` -- the deep pairing. Cortex auto-discovers Memory's retrieval surface, the planning prompt is automatically augmented with task classification, the robot becomes addressable as *"how are you?"*, *"what did you see?"*, and *"go remember the cat for me"*.
+- {doc}`Cortex Driving the Full Stack <../recipes/planning-and-manipulation/cortex-navigation>` -- adds a Kompass navigation stack on top of the Memory + Cortex pair so the robot can act on memory queries instead of just answering them.

--- a/docs/intelligence/models.md
+++ b/docs/intelligence/models.md
@@ -35,22 +35,16 @@ Clients in EmbodiedAgents take as input a **model** or **vector database (DB)** 
   - Provides an interface for loading and running LeRobot policies -- vision-language-action (VLA) models trained for robotic manipulation tasks. Supports automatic extraction of feature and action specifications directly from dataset metadata, as well as flexible configuration of policy behavior. The policy can be instantiated from any compatible LeRobot checkpoint hosted on HuggingFace, making it easy to load pretrained models such as `smolvla_base` or others. This wrapper must be used with the gRPC-based **LeRobotClient**.
 
 * - **RoboBrain2**
-  - [RoboBrain 2.0 by BAAI](https://github.com/FlagOpen/RoboBrain2.0) supports interactive reasoning with long-horizon planning and closed-loop feedback, spatial perception for precise point and bbox prediction from complex instructions, and temporal perception for future trajectory estimation. Checkpoint defaults to `"BAAI/RoboBrain2.0-7B"`, with larger variants available [here](https://huggingface.co/collections/BAAI/robobrain20-6841eeb1df55c207a4ea0036). This wrapper can be used with any of the RoboML clients.
+  - [RoboBrain 2.0 by BAAI](https://github.com/FlagOpen/RoboBrain2.0) supports interactive reasoning with long-horizon planning and closed-loop feedback, spatial perception for precise point and bbox prediction from complex instructions, and temporal perception for future trajectory estimation. Checkpoint defaults to `"BAAI/RoboBrain2.0-3B"`; larger variants (7B, 32B) are at the same [collection](https://huggingface.co/collections/BAAI/robobrain20-6841eeb1df55c207a4ea0036). This wrapper can be used with any of the RoboML clients.
 
 * - **Whisper**
-  - OpenAI's automatic speech recognition (ASR) model with various sizes (e.g., `"small"`, `"large-v3"`, etc.). Available on the [RoboML](https://github.com/automatika-robotics/roboml) platform and can be used with any RoboML client. Recommended: **RoboMLWSClient**.
+  - OpenAI's automatic speech recognition (ASR) model served via [faster-whisper](https://github.com/SYSTRAN/faster-whisper). Default checkpoint `"small.en"`; configurable `compute_type` (`"int8"`, `"float16"`, `"float32"`). Available on the [RoboML](https://github.com/automatika-robotics/roboml) platform and can be used with any RoboML client. Recommended: **RoboMLWSClient**.
 
-* - **SpeechT5**
-  - Microsoft's model for TTS synthesis. Configurable voice selection. Available on the [RoboML](https://github.com/automatika-robotics/roboml) platform and can be used with any RoboML client. Recommended: **RoboMLWSClient**.
-
-* - **Bark**
-  - SunoAI's Bark TTS model. Allows a selection of [voices](https://suno-ai.notion.site/8b8e8749ed514b0cbf3f699013548683?v=bc67cff786b04b50b3ceb756fd05f68c). Available on the [RoboML](https://github.com/automatika-robotics/roboml) platform and can be used with any RoboML client. Recommended: **RoboMLWSClient**.
-
-* - **MeloTTS**
-  - MyShell's multilingual TTS model. Configure via `language` (e.g., `"JP"`) and `speaker_id` (e.g., `"JP-1"`). Available on the [RoboML](https://github.com/automatika-robotics/roboml) platform and can be used with any RoboML client. Recommended: **RoboMLWSClient**.
+* - **TransformersTTS**
+  - A unified wrapper for HuggingFace Transformers TTS models. Automatically detects whether to use generative inference (Bark, SpeechT5) or forward-only inference (VITS). Default checkpoint `"facebook/mms-tts-eng"`; other examples include `"suno/bark-small"` (Bark) and `"microsoft/speecht5_tts"` (SpeechT5, paired with `vocoder_checkpoint="microsoft/speecht5_hifigan"`). For Bark, `voice` selects a voice preset (e.g. `"v2/en_speaker_6"`). Available on the [RoboML](https://github.com/automatika-robotics/roboml) platform and can be used with any RoboML client. Recommended: **RoboMLWSClient**.
 
 * - **VisionModel**
-  - A generic wrapper for object detection and tracking models available on [MMDetection](https://github.com/open-mmlab/mmdetection). Supports optional tracking, configurable thresholds, and deployment with TensorRT. Available on the [RoboML](https://github.com/automatika-robotics/roboml) platform and can be used with any RoboML client. Recommended: **RoboMLRESPClient**.
+  - A generic wrapper for object detection and tracking models from [HuggingFace Transformers](https://huggingface.co/models?pipeline_tag=object-detection) (RT-DETR, DETR, Grounding DINO, YOLOS, etc.). Default checkpoint `"PekingU/rtdetr_r50vd_coco_o365"`. Tracking via [ByteTrack](https://github.com/roboflow/trackers) is included; enable with `setup_trackers=True` and tune via `tracking_distance_threshold`. Available on the [RoboML](https://github.com/automatika-robotics/roboml) platform and can be used with any RoboML client. Recommended: **RoboMLRESPClient**.
 ```
 
 ## Built-in Local Models

--- a/docs/intelligence/overview.md
+++ b/docs/intelligence/overview.md
@@ -8,41 +8,55 @@
 
 - <span class="sd-text-primary" style="font-weight: bold; font-size: 1.1em;">{material-regular}`autorenew;1.2em;sd-text-primary` Self-Referential and Event-Driven</span> -- Agents can start, stop, or reconfigure their own components based on internal and external events. Switch from cloud to local inference, swap planners based on vision input, or adjust behavior on the fly. In the spirit of [Godel machines](https://en.wikipedia.org/wiki/G%C3%B6del_machine), agents become capable of introspecting and modifying their own execution graph at runtime.
 
-- <span class="sd-text-primary" style="font-weight: bold; font-size: 1.1em;">{material-regular}`hub;1.2em;sd-text-primary` Semantic Memory</span> -- Hierarchical spatio-temporal memory and semantic routing for arbitrarily complex agentic information flow. Components like MapEncoding and SemanticRouter let robots maintain structured, queryable representations of their environment over time -- no bloated GenAI frameworks required.
+- <span class="sd-text-primary" style="font-weight: bold; font-size: 1.1em;">{material-regular}`hub;1.2em;sd-text-primary` Semantic Memory & Agentic Planning</span> -- Hierarchical spatio-temporal memory and semantic routing for arbitrarily complex agentic information flow. The graph-backed [Memory](memory.md) component keeps an episodic, entity-aware record of what the robot perceives *and* of its own internal state, while [Cortex](cortex.md) turns plain-language goals into ordered calls against every component in the graph -- no bloated GenAI frameworks required.
 
 - <span class="sd-text-primary" style="font-weight: bold; font-size: 1.1em;">{material-regular}`code;1.2em;sd-text-primary` Pure Python, Native ROS2</span> -- Define complex asynchronous execution graphs in standard Python without touching XML launch files. Underneath, everything is pure ROS2 -- fully compatible with the entire ecosystem of hardware drivers, simulation tools, and visualization suites.
 
 ## What You Can Build
 
-::::{grid} 1 2 2 2
+::::{grid} 1 2 3 3
 :gutter: 3
 
-:::{grid-item-card} {material-regular}`chat;1.2em;sd-text-primary` Conversational Robots
+:::{grid-item-card} {material-regular}`record_voice_over;1.2em;sd-text-primary` Robots You Hold a Conversation With
 :link: ../recipes/foundation/conversational-agent
 :link-type: doc
 
-Speech-to-text, LLM reasoning, and text-to-speech pipelines for natural dialogue.
+Robots that listen, see, and speak -- microphone in, visually-grounded answer out, all in one Python recipe. Ask *"what's on the table?"* and get a real answer in real time.
 :::
 
-:::{grid-item-card} {material-regular}`precision_manufacturing;1.2em;sd-text-primary` Vision-Guided Manipulation
-:link: ../recipes/planning-and-manipulation/vla-manipulation
-:link-type: doc
-
-VLMs for high-level planning and VLAs for end-to-end motor control.
-:::
-
-:::{grid-item-card} {material-regular}`map;1.2em;sd-text-primary` Semantic Navigation
-:link: ../recipes/foundation/goto-navigation
-:link-type: doc
-
-Map encoding and spatio-temporal memory for context-aware movement.
-:::
-
-:::{grid-item-card} {material-regular}`alt_route;1.2em;sd-text-primary` Multi-Modal Agents
+:::{grid-item-card} {material-regular}`alt_route;1.2em;sd-text-primary` Robots That Pick the Right Brain
 :link: ../recipes/foundation/semantic-routing
 :link-type: doc
 
-Dynamically route information between perception, reasoning, and action based on semantic content.
+One sentence in, the right capability fires. *"How tall is Everest?"* wakes the LLM. *"What do you see?"* wakes the VLM. *"Take me to the kitchen."* dispatches the navigation stack. Behavior emerges from intent.
+:::
+
+:::{grid-item-card} {material-regular}`precision_manufacturing;1.2em;sd-text-primary` Robots That Pick Up What You Mean
+:link: ../recipes/planning-and-manipulation/vla-manipulation
+:link-type: doc
+
+A robot arm that grabs *"the red mug next to the laptop"* without you writing a state machine for which mug. A VLM grounds the description; a VLA model translates straight to joint commands.
+:::
+
+:::{grid-item-card} {material-regular}`memory;1.2em;sd-text-primary` Robots That Remember
+:link: ../recipes/foundation/semantic-map
+:link-type: doc
+
+Every detection, every scene caption, every internal reading is folded into a graph indexed by *meaning*, *place*, and *time* -- and persists across reboots. The robot starts knowing your space the way you do.
+:::
+
+:::{grid-item-card} {material-regular}`smart_toy;1.2em;sd-text-primary` Robots You Give Missions To
+:link: ../recipes/planning-and-manipulation/cortex-agent
+:link-type: doc
+
+Drop a [Cortex](cortex.md) component into your recipe and your robot starts running *missions*, not commands. *"Patrol the workshop and tell me if any lights are off."* Cortex auto-discovers every capability as an LLM tool, plans the steps, dispatches them, watches feedback, and replans on failure -- with no orchestration code from you.
+:::
+
+:::{grid-item-card} {material-regular}`route;1.2em;sd-text-primary` Robots That Reason About the World
+:link: ../recipes/planning-and-manipulation/cortex-navigation
+:link-type: doc
+
+Compound goals like *"go to the kitchen and tell me what's on the counter"* fall out of a single recipe. The robot recalls where the kitchen is from memory, navigates there with Kompass, looks at the counter, narrates the answer. End-to-end embodied reasoning, no behavior trees.
 :::
 
 ::::
@@ -50,5 +64,7 @@ Dynamically route information between perception, reasoning, and action based on
 ## Next Steps
 
 - {material-regular}`widgets;1.2em;sd-text-primary` {doc}`ai-components` -- The core building blocks: components and topics.
+- {material-regular}`psychology;1.2em;sd-text-primary` {doc}`cortex` -- The agentic planner-executor that drives the rest of the graph from natural-language goals.
+- {material-regular}`memory;1.2em;sd-text-primary` {doc}`memory` -- Graph-backed spatio-temporal memory with perception and interoception layers.
 - {material-regular}`cloud;1.2em;sd-text-primary` {doc}`clients` -- How inference backends connect to components.
 - {material-regular}`model_training;1.2em;sd-text-primary` {doc}`models` -- Available model wrappers and vector databases.

--- a/docs/navigation/control.md
+++ b/docs/navigation/control.md
@@ -108,7 +108,7 @@ EMOS includes several production-ready control plugins suited for different envi
 
 - {material-regular}`speed;1.2em;sd-text-primary` **[DWA](../advanced/algorithms.md)** — Dynamic Window Approach. Sample-based collision avoidance with GPU support. Considers kinematics to find optimal velocity.
 
-- {material-regular}`visibility;1.2em;sd-text-primary` **[VisionFollower](../advanced/algorithms.md)** — Vision target following controller. Steers the robot to keep a visual target centered using RGB or depth data.
+- {material-regular}`visibility;1.2em;sd-text-primary` **[VisionFollower](../advanced/algorithms.md)** — Vision target following controllers. Steer the robot to keep a visual target centered using RGB or depth data.
 
 See the [Algorithms Reference](../advanced/algorithms.md) for detailed descriptions of each algorithm.
 

--- a/docs/navigation/planning.md
+++ b/docs/navigation/planning.md
@@ -42,7 +42,7 @@ Planner can be used with all four available Run Types:
   - `Topic(name="/map", msg_type="OccupancyGrid", qos_profile=QoSConfig(durability=TRANSIENT_LOCAL))`
 
 * - goal_point
-  - [`nav_msgs.msg.Odometry`](https://docs.ros.org/en/noetic/api/nav_msgs/html/msg/Odometry.html), [`geometry_msgs.msg.PoseStamped`](http://docs.ros.org/en/jade/api/geometry_msgs/html/msg/PoseStamped.html), [`geometry_msgs.msg.PointStamped`](http://docs.ros.org/en/jade/api/geometry_msgs/html/msg/PointStamped.html)
+  - [`nav_msgs.msg.Odometry`](https://docs.ros.org/en/noetic/api/nav_msgs/html/msg/Odometry.html), [`geometry_msgs.msg.PoseStamped`](http://docs.ros.org/en/jade/api/geometry_msgs/html/msg/PoseStamped.html), [`geometry_msgs.msg.PointStamped`](http://docs.ros.org/en/jade/api/geometry_msgs/html/msg/PointStamped.html), `automatika_embodied_agents.msg.Detections`, `automatika_embodied_agents.msg.PointsOfInterest`, `automatika_embodied_agents.msg.Trackings`
   - 1
   - `Topic(name="/goal", msg_type="PointStamped")`
 
@@ -54,6 +54,10 @@ Planner can be used with all four available Run Types:
 
 :::{note}
 `goal_point` input is only used if the Planner is running as TIMED or EVENT Component. In the other two types, the goal point is provided in the service request or the action goal.
+:::
+
+:::{tip}
+**Detections, Points-of-Interest, and Trackings as goals.** The Planner accepts `Detections`, `PointsOfInterest`, and `Trackings` messages from EmbodiedAgents directly on the `goal_point` input. These carry pixel-space coordinates from ML models; when paired with an RGBD source, the depth channel is used to project pixel coordinates to averaged world-space coordinates via camera intrinsics, so a Vision component can drive the Planner without an intermediate `Pose` topic. See [Cortex with Navigation](../recipes/planning-and-manipulation/cortex-navigation.md) and [Multimodal Planning](../recipes/planning-and-manipulation/planning-models.md) for the patterns.
 :::
 
 ## Outputs

--- a/docs/recipes/events-and-resilience/index.md
+++ b/docs/recipes/events-and-resilience/index.md
@@ -28,6 +28,20 @@ Swap models, switch algorithms, and restart hardware -- the same API for both la
 Run a lightweight detector continuously, wake the heavy VLM only when needed.
 :::
 
+:::{grid-item-card} {material-regular}`account_tree;1.2em;sd-text-primary` Visualizing the System Graph
+:link: visualizing-system-graph
+:link-type: doc
+
+Tour the System Graph view in the Web UI -- components, topics, events, and actions of the whole running recipe.
+:::
+
+:::{grid-item-card} {material-regular}`change_history;1.2em;sd-text-primary` Internal-State Events
+:link: internal-state-events
+:link-type: doc
+
+Build events from any Python callable returning bool, calculated compound signals or hardware monitors, polled at a configurable rate.
+:::
+
 :::{grid-item-card} {material-regular}`sensors;1.2em;sd-text-primary` External Reflexes
 :link: external-reflexes
 :link-type: doc

--- a/docs/recipes/events-and-resilience/internal-state-events.md
+++ b/docs/recipes/events-and-resilience/internal-state-events.md
@@ -1,0 +1,149 @@
+# Internal-State Events
+
+Most events fire on **topic data** — *"battery dropped below 15%"*, *"a person was detected"*, *"the controller reported failure"*. These are clean and declarative, but they share an assumption: the trigger condition can be expressed as a predicate over messages flowing through the system as a published topic.
+
+Sometimes that's not enough. The thing you want to react to is **internal state**:
+
+- A hardware monitor that is not being published as a topic.
+- A compound predicate over multiple disparate signals.
+- A hysteresis flag that's *sticky* across cycles.
+
+For these cases, EMOS supports **callable-based events**: an `Event` constructed from any Python callable that returns `bool`, polled at a configurable rate. The callable holds whatever state it needs — a closure variable, a class attribute, a global counter — and the Monitor polls it at `check_rate` Hz. When it returns `True`, registered Actions fire just like for any other event.
+
+```{seealso}
+For the conceptual reference, see [Events & Actions → Events from Internal State](../../concepts/events-and-actions.md#events-from-internal-state). For visualising live events in the Web UI, see [Visualizing Events](visualizing-events.md).
+```
+
+---
+
+## The Mechanic
+
+An `Event` accepts three kinds of `event_condition`:
+
+1. A `Topic` — fires on any new message.
+2. A `Condition` expression — fires when a predicate over topic attributes becomes true.
+3. **A `Callable` returning `bool`** — fires when polling the callable returns true.
+
+The third form is what we use here:
+
+```python
+from ros_sugar.event import Event
+
+def is_low_power() -> bool:  # must be type-annotated as bool
+    ...
+
+event_low_power = Event(is_low_power, check_rate=1.0)  # polled every 1 second
+```
+
+Two rules from the `Event` constructor:
+
+- The callable's return type annotation **must be `bool`**. The constructor inspects it and raises `TypeError` otherwise.
+- The callable **cannot be a `@component_action`** method bound to a managed component's lifecycle. Use a plain function or a regular instance method instead.
+
+`check_rate` is in **Hz**. If omitted, the event polls at the central Monitor's loop rate. For most real-world predicates, anywhere from 0.5–5 Hz is sensible — fast enough to catch transitions, slow enough to be cheap.
+
+---
+
+## Recipe: Idle Detection
+
+A robot that listens for voice commands should react when there's been no input for a while — dim its display, switch to a lighter local model, or just go quiet. *"Idleness"* isn't a value on any topic; it's a derived predicate over time and the most recent input. Perfect fit for a callable-based event.
+
+### Step 1: A stateful predicate
+
+Hold the *last interaction* timestamp in a tiny helper class and expose a typed `is_idle` method:
+
+```python
+import time
+
+
+class IdleTracker:
+    """Tracks how long it has been since the last user interaction."""
+
+    def __init__(self, threshold_seconds: float = 60.0) -> None:
+        self.threshold_seconds = threshold_seconds
+        self._last_seen = time.time()
+
+    def touch(self) -> None:
+        """Mark 'just had user interaction' -- call this from your input pipeline."""
+        self._last_seen = time.time()
+
+    def is_idle(self) -> bool:
+        """True when we haven't seen interaction for ``threshold_seconds``."""
+        return (time.time() - self._last_seen) > self.threshold_seconds
+
+
+idle = IdleTracker(threshold_seconds=60.0)
+```
+
+Two methods — `touch()` to update state, `is_idle()` to read it. The `-> bool` annotation on `is_idle` is mandatory; the `Event` constructor inspects it.
+
+### Step 2: Wire the state update
+
+Whenever the Speech-to-Text component publishes a transcribed query, we want to call `idle.touch()`. EMOS lets us hook a small pre-processor on the publishing side of any topic:
+
+```python
+from typing import Optional
+
+
+def touch_on_speech(text: str) -> Optional[str]:
+    idle.touch()
+    return text  # pass through unchanged
+
+
+speech_to_text.add_publisher_preprocessor(query_topic, touch_on_speech)
+```
+
+The pre-processor runs in-process before publication. It updates `idle._last_seen` and passes the message through untouched. Any topic update mechanism would work — a callback, a periodic component, a subscriber elsewhere. The point is that the *state* lives in `idle`, not in any topic.
+
+### Step 3: Build the Event and an Action
+
+```python
+from ros_sugar.actions import log
+from ros_sugar.event import Event
+
+event_idle = Event(idle.is_idle, check_rate=0.5)  # poll every 2 seconds
+
+events_actions = {
+    event_idle: [
+        log(msg="No interaction for 60s -- switching to low-power mode"),
+        # ...switch to a smaller model, dim a display, etc.
+    ],
+}
+```
+
+`check_rate=0.5` means Mermaid checks `idle.is_idle()` every 2 seconds. As long as `touch_on_speech` keeps firing, `is_idle()` returns False; the moment 60 seconds elapse without a query, the next poll returns True and the Action fires.
+
+### Step 4: Hand the events_actions dict to the Launcher
+
+```python
+from agents.ros import Launcher
+
+launcher = Launcher()
+launcher.add_pkg(
+    components=[speech_to_text, vlm, text_to_speech],
+    events_actions=events_actions,
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
+)
+launcher.bringup()
+```
+
+The Monitor (or `Cortex`, if it's the recipe's monitor) takes ownership of the polling loop. From this point on, every 2 seconds the Monitor calls `idle.is_idle()` and fires the registered Actions on rising-edge transitions.
+
+---
+
+## When to reach for this pattern
+
+Use a callable-based event when:
+
+- The condition is **internal state** that has no business being a topic (counters, timers, sticky flags, last-seen timestamps).
+- The condition is a **compound predicate** over multiple sources that's easier to express as an arbitrary calculation in Python rather than as a chain of topic conditions.
+- You want **encapsulation** — keep the state inside the recipe rather than smearing it across publisher topics just to satisfy the trigger.
+
+Use a topic-based event when the condition genuinely is *"some message arrived"* or *"this attribute crossed a threshold"*. Topic events are cheaper (push, no polling) and more declarative.
+
+---
+
+## Visualisation
+
+Callable-based events show up on the [System Graph](../../concepts/web-ui.md) too: the source component (or the recipe-level dispatcher) is the upstream node, and the registered Actions are the downstream nodes. The detail card lists `check_rate` and the current trigger count, so you can confirm at runtime that the predicate is actually flipping when you expect it to. See [Visualizing Events](visualizing-events.md) for the tour.

--- a/docs/recipes/events-and-resilience/internal-state-events.md
+++ b/docs/recipes/events-and-resilience/internal-state-events.md
@@ -111,7 +111,7 @@ events_actions = {
 }
 ```
 
-`check_rate=0.5` means Mermaid checks `idle.is_idle()` every 2 seconds. As long as `touch_on_speech` keeps firing, `is_idle()` returns False; the moment 60 seconds elapse without a query, the next poll returns True and the Action fires.
+`check_rate=0.5` means the Monitor checks `idle.is_idle()` every 2 seconds. As long as `touch_on_speech` keeps firing, `is_idle()` returns False; the moment 60 seconds elapse without a query, the next poll returns True and the Action fires.
 
 ### Step 4: Hand the events_actions dict to the Launcher
 

--- a/docs/recipes/events-and-resilience/internal-state-events.md
+++ b/docs/recipes/events-and-resilience/internal-state-events.md
@@ -11,7 +11,7 @@ Sometimes that's not enough. The thing you want to react to is **internal state*
 For these cases, EMOS supports **callable-based events**: an `Event` constructed from any Python callable that returns `bool`, polled at a configurable rate. The callable holds whatever state it needs — a closure variable, a class attribute, a global counter — and the Monitor polls it at `check_rate` Hz. When it returns `True`, registered Actions fire just like for any other event.
 
 ```{seealso}
-For the conceptual reference, see [Events & Actions → Events from Internal State](../../concepts/events-and-actions.md#events-from-internal-state). For visualising live events in the Web UI, see [Visualizing Events](visualizing-events.md).
+For the conceptual reference, see [Events & Actions](../../concepts/events-and-actions.md). For inspecting live events in the Web UI, see [Visualizing the System Graph](visualizing-system-graph.md).
 ```
 
 ---
@@ -146,4 +146,4 @@ Use a topic-based event when the condition genuinely is *"some message arrived"*
 
 ## Visualisation
 
-Callable-based events show up on the [System Graph](../../concepts/web-ui.md) too: the source component (or the recipe-level dispatcher) is the upstream node, and the registered Actions are the downstream nodes. The detail card lists `check_rate` and the current trigger count, so you can confirm at runtime that the predicate is actually flipping when you expect it to. See [Visualizing Events](visualizing-events.md) for the tour.
+Callable-based events show up on the [System Graph](../../concepts/web-ui.md) too: the source component (or the recipe-level dispatcher) is the upstream node, and the registered Actions are the downstream nodes. The detail card lists `check_rate` and the current trigger count, so you can confirm at runtime that the predicate is actually flipping when you expect it to. See [Visualizing the System Graph](visualizing-system-graph.md) for the tour.

--- a/docs/recipes/events-and-resilience/multiprocessing.md
+++ b/docs/recipes/events-and-resilience/multiprocessing.md
@@ -193,7 +193,7 @@ position = Topic(name="odom", msg_type="Odometry")
 
 memory = Memory(
     layers=[
-        MemLayer(subscribes_to=detections_topic, temporal_change=True),
+        MemLayer(subscribes_to=detections_topic),
         MemLayer(subscribes_to=introspection_answer),
     ],
     position=position,
@@ -290,7 +290,7 @@ mllm_route = Route(
         "Whats in front of you?",
         "Where are we",
         "Do you see any people?",
-        "How many things are infront of you?",
+        "How many things are in front of you?",
         "Is this room occupied?",
     ],
 )

--- a/docs/recipes/events-and-resilience/multiprocessing.md
+++ b/docs/recipes/events-and-resilience/multiprocessing.md
@@ -1,88 +1,114 @@
 # Multiprocessing & Fault Tolerance
 
-In the previous recipes we saw how we can make a complex graph of components to create an intelligent embodied agent. In this recipe we will have a look at some of the features that EMOS provides to make the same system robust and production-ready.
+In the previous recipes we saw how to compose a complex graph of components into an intelligent embodied agent. In this recipe we look at the features EMOS provides to make the same graph **robust and production-ready** -- running every component in its own process for crash isolation, and adding component-level and process-level recovery so a transient failure doesn't bring the whole system down.
+
+```{admonition} Prerequisites
+:class: important
+
+This recipe builds on [Complete Agent](../foundation/complete-agent.md). Memory needs the [eMEM](https://github.com/automatika-robotics/emem) package: `pip install emem`.
+```
 
 ## Run Components in Separate Processes
 
-The first thing we want to do is to run each component in a different process. By default our launcher launches each component in a separate thread, however ROS was designed such that each functional unit (a component in EMOS, that maps to a node in ROS) runs in a separate process such that failure of one process does not crash the whole system. In order to enable multiprocessing we simply pass the name of our ROS package, i.e. `automatika_embodied_agents` and the multiprocessing parameter to our launcher as follows:
+By default the launcher runs each component in its own thread. ROS, however, was designed so that each functional unit -- a component in EMOS, mapped to a node in ROS -- runs in a **separate process**, such that failure of one process does not crash the rest of the system. We enable multiprocessing by passing `multiprocessing=True` and the ROS package name to `add_pkg`:
 
 ```python
-launcher = Launcher()
 launcher.add_pkg(
-    components=[
-        mllm,
-        llm,
-        goto,
-        introspector,
-        map,
-        router,
-        speech_to_text,
-        text_to_speech,
-        vision
-    ],
+    components=all_components,
     package_name="automatika_embodied_agents",
-    multiprocessing=True
+    multiprocessing=True,
 )
 ```
 
-## Adding Fallback Behavior
+## Component-Level Fallbacks
 
-EMOS provides fallback behaviors in case a component fails. For example in components that send inference requests to machine learning models, a failure can happen if the model client cannot connect to the model serving platform due to a connection glitch or a failure at the end of the platform. To handle such a case we can restart our component, which will make it check connection with the model serving platform during its activation. The component will remain in an unhealthy state until it successfully activates, and it will keep on executing fallback behavior until it remains unhealthy. This fallback behavior can be specified in the launcher which will automatically apply it to all components. We can also add a time interval between consecutive fallback actions. All of this can be done by passing the following parameters to the launcher before bring up:
+When a component fails -- a model server drops, a sensor goes dead, an algorithm can't find a solution -- EMOS lets us register **fallback strategies** that the component executes automatically. The simplest one is *restart*: re-run the lifecycle so the component checks its inputs and connections again before returning to the active state. We attach this to every component in the recipe with a small loop:
 
 ```python
-launcher.on_fail(action_name="restart")
-launcher.fallback_rate = 1 / 10  # 0.1 Hz or 10 seconds
+from agents.ros import Action
+
+for component in all_components:
+    component.on_fail(
+        action=Action(component.restart),
+        max_retries=2,
+    )
+    component.fallback_rate = 1 / 10  # 0.1 Hz -- check for failures every 10s
 ```
+
+`on_fail` registers the action to take when the component reports an unhealthy state; `fallback_rate` controls how often EMOS retries while the component stays unhealthy.
 
 ```{seealso}
-EMOS provides advanced fallback behaviors at the component level. To learn more about these, checkout the [Fallback](../../concepts/status-and-fallbacks.md) documentation.
+EMOS supports much richer fallback behaviour -- escalation ladders, custom handlers, the four-level health-status hierarchy. See [Status & Fallbacks](../../concepts/status-and-fallbacks.md) for the full picture.
 ```
 
-With these two simple modifications, our complex graph of an embodied agent can be made significantly more robust to failures and has a graceful fallback behavior in case a failure does occur. The complete agent code is as follows:
+## Process-Level Crash Recovery
+
+Component-level fallbacks handle the case where a component is *running* but unhealthy. They cannot help if the entire process **crashes** -- a segfault, an OOM kill, an unhandled native exception. For that, EMOS provides `Launcher.on_process_fail`, which respawns any component process that exits with a non-zero status outside of a clean shutdown:
 
 ```python
-import numpy as np
-import json
+launcher.on_process_fail(max_retries=3)
+```
+
+The two layers compose: the in-process fallback tries to restart the component up to 2 times; if those fail and the process actually exits, the launcher respawns the process up to 3 times. See [Process-Level Recovery](../../concepts/status-and-fallbacks.md#process-level-recovery) for the full discussion.
+
+## The Complete Recipe
+
+Putting it all together:
+
+```python
+import re
 from typing import Optional
+
+import numpy as np
+
+from agents.clients import (
+    ChromaClient,
+    OllamaClient,
+    RoboMLHTTPClient,
+    RoboMLRESPClient,
+)
 from agents.components import (
-    MLLM,
+    LLM,
+    VLM,
+    Memory,
+    SemanticRouter,
     SpeechToText,
     TextToSpeech,
-    LLM,
     Vision,
-    MapEncoding,
-    SemanticRouter,
 )
-from agents.config import TextToSpeechConfig
-from agents.clients import RoboMLHTTPClient, RoboMLRESPClient
-from agents.clients import ChromaClient
-from agents.clients import OllamaClient
-from agents.models import Whisper, SpeechT5, VisionModel, OllamaModel
+from agents.config import (
+    LLMConfig,
+    MemoryConfig,
+    SemanticRouterConfig,
+    TextToSpeechConfig,
+    VisionConfig,
+)
+from agents.models import OllamaModel, TransformersTTS, VisionModel, Whisper
+from agents.ros import Action, FixedInput, Launcher, MemLayer, Route, Topic
 from agents.vectordbs import ChromaDB
-from agents.config import VisionConfig, LLMConfig, MapConfig, SemanticRouterConfig
-from agents.ros import Topic, Launcher, FixedInput, MapLayer, Route
 
 
-### Setup our models and vectordb ###
-whisper = Whisper(name="whisper")
-whisper_client = RoboMLHTTPClient(whisper)
-speecht5 = SpeechT5(name="speecht5")
-speecht5_client = RoboMLHTTPClient(speecht5)
-object_detection_model = VisionModel(
-    name="dino_4scale", checkpoint="dino-4scale_r50_8xb2-12e_coco"
+### Models and shared clients ###
+whisper_client = RoboMLHTTPClient(Whisper(name="whisper"))
+tts_client = RoboMLHTTPClient(TransformersTTS(name="tts"))
+detection_client = RoboMLRESPClient(
+    VisionModel(name="rtdetr", checkpoint="PekingU/rtdetr_r50vd_coco_o365")
 )
-detection_client = RoboMLRESPClient(object_detection_model)
-qwen_vl = OllamaModel(name="qwen_vl", checkpoint="qwen2.5vl:latest")
-qwen_client = OllamaClient(qwen_vl)
-llama = OllamaModel(name="llama", checkpoint="llama3.2:3b")
-llama_client = OllamaClient(llama)
-chroma = ChromaDB()
-chroma_client = ChromaClient(db=chroma)
+qwen_vl_client = OllamaClient(
+    OllamaModel(name="qwen_vl", checkpoint="qwen2.5vl:latest")
+)
+qwen_client = OllamaClient(OllamaModel(name="qwen", checkpoint="qwen3:0.6b"))
+embedding_client = OllamaClient(
+    OllamaModel(name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest")
+)
+# ChromaDB is still used by SemanticRouter for route embeddings.
+chroma_client = ChromaClient(db=ChromaDB(), port=8080)
 
-### Setup our components ###
-# Setup a speech to text component
+
+### Speech I/O ###
 audio_in = Topic(name="audio0", msg_type="Audio")
 query_topic = Topic(name="question", msg_type="String")
+query_answer = Topic(name="answer", msg_type="String")
 
 speech_to_text = SpeechToText(
     inputs=[audio_in],
@@ -92,63 +118,63 @@ speech_to_text = SpeechToText(
     component_name="speech_to_text",
 )
 
-# Setup a text to speech component
-query_answer = Topic(name="answer", msg_type="String")
-
-t2s_config = TextToSpeechConfig(play_on_device=True)
-
 text_to_speech = TextToSpeech(
     inputs=[query_answer],
     trigger=query_answer,
-    model_client=speecht5_client,
-    config=t2s_config,
+    model_client=tts_client,
+    config=TextToSpeechConfig(play_on_device=True),
     component_name="text_to_speech",
 )
 
-# Setup a vision component for object detection
+
+### Vision (object detection) ###
 image0 = Topic(name="image_raw", msg_type="Image")
 detections_topic = Topic(name="detections", msg_type="Detections")
 
-detection_config = VisionConfig(threshold=0.5)
 vision = Vision(
     inputs=[image0],
     outputs=[detections_topic],
     trigger=image0,
-    config=detection_config,
+    config=VisionConfig(threshold=0.5),
     model_client=detection_client,
     component_name="object_detection",
 )
 
-# Define a generic mllm component for vqa
+
+### VQA VLM ###
 mllm_query = Topic(name="mllm_query", msg_type="String")
 
-mllm = MLLM(
+mllm = VLM(
     inputs=[mllm_query, image0, detections_topic],
     outputs=[query_answer],
-    model_client=qwen_client,
+    model_client=qwen_vl_client,
     trigger=mllm_query,
     component_name="visual_q_and_a",
 )
-
 mllm.set_component_prompt(
-    template="""Imagine you are a robot.
-    This image has following items: {{ detections }}.
-    Answer the following about this image: {{ text0 }}"""
+    template=(
+        "Imagine you are a robot. This image has the following items: "
+        "{{ detections }}. Answer the following about this image: {{ text0 }}"
+    )
 )
 
-# Define a fixed input mllm component that does introspection
+
+### Introspection VLM (room classification feeding the memory) ###
 introspection_query = FixedInput(
     name="introspection_query",
     msg_type="String",
-    fixed="What kind of a room is this? Is it an office, a bedroom or a kitchen? Give a one word answer, out of the given choices",
+    fixed=(
+        "What kind of a room is this? Is it an office, a bedroom or a "
+        "kitchen? Give a one word answer, out of the given choices"
+    ),
 )
 introspection_answer = Topic(name="introspection_answer", msg_type="String")
 
-introspector = MLLM(
+introspector = VLM(
     inputs=[introspection_query, image0],
     outputs=[introspection_answer],
-    model_client=qwen_client,
-    trigger=15.0,
+    model_client=qwen_vl_client,
+    trigger=10.0,
     component_name="introspector",
 )
 
@@ -161,92 +187,81 @@ def introspection_validation(output: str) -> Optional[str]:
 
 introspector.add_publisher_preprocessor(introspection_answer, introspection_validation)
 
-# Define a semantic map using MapEncoding component
-layer1 = MapLayer(subscribes_to=detections_topic, temporal_change=True)
-layer2 = MapLayer(
-    subscribes_to=introspection_answer,
-    resolution_multiple=3,
-    pre_defined=[(np.array([1.1, 2.1, 3.2]), "The door is here. DOOR.")],
-)
 
+### Memory (graph-backed spatio-temporal memory) ###
 position = Topic(name="odom", msg_type="Odometry")
-map_topic = Topic(name="map", msg_type="OccupancyGrid")
 
-map_conf = MapConfig(map_name="map")
-map = MapEncoding(
-    layers=[layer1, layer2],
+memory = Memory(
+    layers=[
+        MemLayer(subscribes_to=detections_topic, temporal_change=True),
+        MemLayer(subscribes_to=introspection_answer),
+    ],
     position=position,
-    map_topic=map_topic,
-    config=map_conf,
-    db_client=chroma_client,
+    model_client=qwen_client,
+    embedding_client=embedding_client,
+    config=MemoryConfig(db_path="/tmp/complete_agent_multiprocessing.db"),
     trigger=15.0,
-    component_name="map_encoder",
+    component_name="memory",
 )
 
-# Define a generic LLM component
+
+### Generic LLM (general Q&A) ###
 llm_query = Topic(name="llm_query", msg_type="String")
 
 llm = LLM(
     inputs=[llm_query],
     outputs=[query_answer],
-    model_client=llama_client,
+    model_client=qwen_client,
     trigger=[llm_query],
     component_name="general_q_and_a",
 )
 
-# Define a Go-to-X component using LLM
+
+### Go-to-X using LLM tool calling on Memory.locate ###
 goto_query = Topic(name="goto_query", msg_type="String")
 goal_point = Topic(name="goal_point", msg_type="PoseStamped")
-
-goto_config = LLMConfig(
-    enable_rag=True,
-    collection_name="map",
-    distance_func="l2",
-    n_results=1,
-    add_metadata=True,
-)
 
 goto = LLM(
     inputs=[goto_query],
     outputs=[goal_point],
-    model_client=llama_client,
-    config=goto_config,
-    db_client=chroma_client,
+    model_client=qwen_client,
     trigger=goto_query,
+    config=LLMConfig(),
     component_name="go_to_x",
 )
-
 goto.set_component_prompt(
-    template="""From the given metadata, extract coordinates and provide
-    the coordinates in the following json format:\n {"position": coordinates}"""
+    template=(
+        "The user asks you to go to a place. Use the available tools to "
+        "look up the place's location in memory. Pass the place name to "
+        "the locate tool as the ``concept`` argument. User asked: {{goto_query}}"
+    )
 )
+memory.register_tools_on(goto, tools=["locate"], send_tool_response_to_model=False)
 
 
-# pre-process the output before publishing to a topic of msg_type PoseStamped
-def llm_answer_to_goal_point(output: str) -> Optional[np.ndarray]:
-    # extract the json part of the output string (including brackets)
-    # one can use sophisticated regex parsing here but we'll keep it simple
-    json_string = output[output.find("{") : output.rfind("}") + 1]
-    # load the string as a json and extract position coordinates
-    # if there is an error, return None, i.e. no output would be published to goal_point
-    try:
-        json_dict = json.loads(json_string)
-        coordinates = np.fromstring(json_dict["position"], sep=",", dtype=np.float64)
-        print("Coordinates Extracted:", coordinates)
-        if coordinates.shape[0] < 2 or coordinates.shape[0] > 3:
-            return
-        elif (
-            coordinates.shape[0] == 2
-        ):  # sometimes LLMs avoid adding the zeros of z-dimension
-            coordinates = np.append(coordinates, 0)
-        return coordinates
-    except Exception:
+_LOCATION_RE = re.compile(r"Location:\s*\(([^)]+)\)")
+
+
+def locate_text_to_goal_point(output: str) -> Optional[np.ndarray]:
+    """Pull the centroid coordinates out of Memory.locate's text output."""
+    match = _LOCATION_RE.search(output)
+    if not match:
         return
+    try:
+        coords = np.fromstring(match.group(1), sep=",", dtype=np.float64)
+    except ValueError:
+        return
+    if coords.shape[0] == 2:
+        coords = np.append(coords, 0.0)
+    if coords.shape[0] != 3:
+        return
+    return coords
 
 
-goto.add_publisher_preprocessor(goal_point, llm_answer_to_goal_point)
+goto.add_publisher_preprocessor(goal_point, locate_text_to_goal_point)
 
-# Define a semantic router between a generic LLM component, VQA MLLM component and Go-to-X component
+
+### Semantic router (uses ChromaDB for the route embeddings) ###
 goto_route = Route(
     routes_to=goto_query,
     samples=[
@@ -257,7 +272,6 @@ goto_route = Route(
         "Go to hallway",
     ],
 )
-
 llm_route = Route(
     routes_to=llm_query,
     samples=[
@@ -268,7 +282,6 @@ llm_route = Route(
         "Whats up?",
     ],
 )
-
 mllm_route = Route(
     routes_to=mllm_query,
     samples=[
@@ -282,35 +295,50 @@ mllm_route = Route(
     ],
 )
 
-router_config = SemanticRouterConfig(router_name="go-to-router", distance_func="l2")
-# Initialize the router component
 router = SemanticRouter(
     inputs=[query_topic],
     routes=[llm_route, goto_route, mllm_route],
     default_route=llm_route,
-    config=router_config,
+    config=SemanticRouterConfig(router_name="go-to-router", distance_func="l2"),
     db_client=chroma_client,
     component_name="router",
 )
 
-# Launch the components
+
+### Per-component fallback strategies ###
+all_components = [
+    mllm,
+    llm,
+    goto,
+    introspector,
+    memory,
+    router,
+    speech_to_text,
+    text_to_speech,
+    vision,
+]
+for component in all_components:
+    component.on_fail(
+        action=Action(component.restart),
+        max_retries=2,
+    )
+    component.fallback_rate = 1 / 10  # 0.1 Hz -- check for failures every 10s
+
+
+### Launch (multi-process) ###
 launcher = Launcher()
+launcher.enable_ui(
+    inputs=[query_topic, audio_in], outputs=[detections_topic, query_answer, goal_point]
+)
 launcher.add_pkg(
-    components=[
-        mllm,
-        llm,
-        goto,
-        introspector,
-        map,
-        router,
-        speech_to_text,
-        text_to_speech,
-        vision,
-    ],
+    components=all_components,
     package_name="automatika_embodied_agents",
     multiprocessing=True,
 )
-launcher.on_fail(action_name="restart")
-launcher.fallback_rate = 1 / 10  # 0.1 Hz or 10 seconds
+# Process-level crash recovery: respawn any multi-process component whose
+# process exits unexpectedly, up to ``max_retries`` times.
+launcher.on_process_fail(max_retries=3)
 launcher.bringup()
 ```
+
+With these modifications, the same complex agent graph from [Complete Agent](../foundation/complete-agent.md) runs **as nine isolated processes**, each with its own restart policy and its own process-level safety net. A model-server outage triggers a component restart; an unrecoverable process exit triggers a process respawn. The graph as a whole keeps running.

--- a/docs/recipes/events-and-resilience/visualizing-system-graph.md
+++ b/docs/recipes/events-and-resilience/visualizing-system-graph.md
@@ -1,0 +1,71 @@
+# Visualizing the System Graph
+
+EMOS recipes get rich quickly: a dozen components, topics flowing between them, events firing into actions, fallbacks layered on top. Reading a Python script doesn't always tell you whether the wiring matches what you intended -- a perception edge you thought was feeding the planner might be going to nothing, an event you thought was triggering an action might be sitting idle, and a process you thought was reacting to a topic might never have subscribed.
+
+The launcher's [Dynamic Web UI](../../concepts/web-ui.md) ships a **System Graph** view that renders the _whole running recipe_ as a draggable, resizable node graph -- components, topics, events, and actions all in one place. This recipe walks through using it on a recipe you already have.
+
+```{seealso}
+For the broader feature list of the Web UI, see [Dynamic Web UI](../../concepts/web-ui.md). For the events/actions wiring conceptually, see [Events & Actions](../../concepts/events-and-actions.md).
+```
+
+---
+
+## Step 1: Pick (or build) any recipe
+
+Any recipe with more than one component will give you something to look at, though the graph is most useful for ones with non-trivial wiring -- multiple components feeding each other, events triggering actions, fallbacks attached. The [Complete Agent](../foundation/complete-agent.md) is a good starter (nine components, a router, memory, navigation hooks). If you're working on a navigation system, the [Cortex with Navigation](../planning-and-manipulation/cortex-navigation.md) recipe gives you an even meatier graph with both perception and motion components plus a Cortex hub.
+
+Make sure the launcher comes up with the Web UI enabled:
+
+```python
+launcher.enable_ui(
+    inputs=[...],
+    outputs=[...],
+)
+launcher.bringup()
+```
+
+---
+
+## Step 2: Open the System Graph
+
+Run the recipe and open the launcher Web UI in a browser (default: `http://localhost:5001`). You'll see the standard Dynamic Web UI with the components' settings panels and any inputs/outputs you've registered. The new **System Graph** tab sits alongside those panels.
+
+  <p align="center">
+  <picture align="center">
+    <img alt="System Graph view in the Web UI" src="https://automatikarobotics.com/docs/system_vis_ui.gif" width="90%">
+  </picture>
+  </p>
+
+What you'll see:
+
+- {material-regular}`hub;1.2em;sd-text-primary` **Component nodes** -- one per component, labelled with the component name, colour-coded by lifecycle state.
+- {material-regular}`compare_arrows;1.2em;sd-text-primary` **Topic edges** -- arrows in the direction of data flow. Input edges enter from the left of a component, output edges leave from the right.
+- {material-regular}`flash_on;1.2em;sd-text-primary` **Event nodes** -- yellow event markers placed between the component(s) whose topics the event watches and the action(s) it triggers.
+- {material-regular}`bolt;1.2em;sd-text-primary` **Action nodes** -- blue markers attached to the events that fire them.
+
+The whole graph is **draggable and resizable**, so you can pull a busy region out for a closer look without losing the rest.
+
+---
+
+## Step 3: Inspect anything
+
+Click any element to open its **detail card** -- nodes, edges, events, and actions all have one.
+
+- **Components** -- inputs/outputs, current lifecycle state, the model client (if any), declared `@component_action`s, registered fallbacks.
+- **Topics** -- name, message type, the publishing component, the subscribing component(s), the latest message preview if applicable.
+- **Events** -- the condition expression in serialised form (the same combinator logic `&` / `|` / `~` you wrote, rendered as a tree), the topic(s) it watches, the action(s) registered against it, and the current trigger count.
+- **Actions** -- the target method, the arguments (including any bound topic data), and the count of times it has fired.
+
+The detail card is the fastest way to confirm that an event you authored as `~event_a & event_b` is registered with that exact shape, that a topic you thought was subscribed actually has a subscriber, or that a component is in the lifecycle state you expect.
+
+```{tip}
+If an event you expect to see never fires, the detail card's *trigger count = 0* is the easiest diagnostic. Combine it with the action-server logs surfaced in the main logging card to follow the full trace.
+```
+
+---
+
+## What to use it for
+
+- **Sanity-checking a new recipe** -- confirm every component you added is wired the way you intended before you start chasing bugs.
+- **Operator handover** -- the graph is a self-documenting handoff artefact. Screenshot it for a runbook.
+- **Failure investigation** -- when an event isn't firing, the detail card and trigger count usually point at the wiring problem before logs do.

--- a/docs/recipes/foundation/complete-agent.md
+++ b/docs/recipes/foundation/complete-agent.md
@@ -1,50 +1,152 @@
 # Complete Agent
 
-This is the capstone recipe. Everything we have built in the previous tutorials -- conversational interfaces, prompt engineering, semantic mapping, RAG-powered navigation, and semantic routing -- comes together here into a single EMOS Recipe: a fully capable embodied agent defined in one Python script.
+This is the capstone recipe. Everything we have built in the previous tutorials -- conversational interfaces, prompt engineering, spatio-temporal memory, memory-aware navigation, and semantic routing -- comes together here into a single EMOS recipe: a fully capable embodied agent defined in one Python script.
 
 This is what EMOS is designed for. Instead of stitching together dozens of ROS nodes, launch files, and custom middleware, you define a complete agentic workflow as a graph of [Components](../../intelligence/ai-components.md) connected through [Topics](../../concepts/topics.md), and bring it up with a single call. The result is a robot that can listen, see, think, remember, navigate, and speak -- all orchestrated by EMOS.
+
+```{seealso}
+For the multiprocessing-and-fault-tolerant variant of this recipe, see [Multiprocessing & Fault Tolerance](../events-and-resilience/multiprocessing.md). For the agentic-harness variant where a single [Cortex](../../intelligence/cortex.md) component takes charge of an entire graph like this, see [Memory and Cortex](../planning-and-manipulation/cortex-memory.md) and [Embodied Reasoning with Cortex](../planning-and-manipulation/cortex-navigation.md).
+```
+
+```{admonition} Prerequisites
+:class: important
+
+This recipe uses the `Memory` component for spatio-temporal memory. Memory needs the [eMEM](https://github.com/automatika-robotics/emem) package: `pip install emem`. Audio playback also needs `pip install soundfile sounddevice`.
+```
+
+## The Graph
+
+```{mermaid}
+flowchart LR
+    %% --- External I/O ---
+    query([query])
+    Kompass([Kompass])
+
+    %% --- Speech I/O ---
+    speech_to_text[speech_to_text]:::component
+    text_to_speech[text_to_speech]:::component
+    Whisper[Whisper]
+    TransformersTTS[TransformersTTS]
+
+    %% --- Model / DB backends ---
+    ChromaDB[ChromaDB]
+
+    %% --- Routing ---
+    router[router]:::component
+
+    %% --- Vision ---
+    object_detection[object_detection]:::component
+    RT_DETR[RT-DETR]
+
+    %% --- VLM (VQA + introspection) ---
+    visual_q_and_a[visual_q_and_a]:::component
+    introspector[introspector]:::component
+    qwen_vl[qwen_vl Ollama]
+
+    %% --- LLM brains ---
+    general_q_and_a[general_q_and_a]:::component
+    go_to_x[go_to_x]:::component
+    qwen[qwen Ollama]
+
+    %% --- Memory ---
+    memory[memory]:::component
+    embeddings[embeddings Ollama]
+
+    %% --- Wiring: input → router → routes ---
+    query --> speech_to_text
+    Whisper <--> speech_to_text
+    speech_to_text --> router
+    router <--> ChromaDB
+    router --> visual_q_and_a
+    router --> general_q_and_a
+    router --> go_to_x
+
+    %% --- Vision feeds VQA + memory ---
+    RT_DETR <--> object_detection
+    object_detection --> visual_q_and_a
+    object_detection --> memory
+
+    %% --- VLM clients ---
+    qwen_vl <--> visual_q_and_a
+    qwen_vl <--> introspector
+    introspector --> memory
+
+    %% --- LLM clients ---
+    qwen <--> general_q_and_a
+    qwen <--> go_to_x
+    qwen <--> memory
+
+    %% --- Memory's own backbone ---
+    embeddings <--> memory
+    memory --> go_to_x
+
+    %% --- Outputs back to speech / navigation ---
+    visual_q_and_a --> text_to_speech
+    general_q_and_a --> text_to_speech
+    TransformersTTS <--> text_to_speech
+    go_to_x --> Kompass
+
+    classDef component fill:#e07a7a,stroke:#a64545,stroke-width:1.5px,color:#000000
+```
+
+Rectangular boxes are EMOS components, their model backends, and the embedded ChromaDB the router uses for route-embedding lookups. The rounded nodes are the things outside this recipe -- the user's input on one side and the Kompass navigation stack on the other.
 
 ## The Complete Recipe
 
 ```python
-import numpy as np
-import json
+import re
 from typing import Optional
+
+import numpy as np
+
+from agents.clients import (
+    ChromaClient,
+    OllamaClient,
+    RoboMLHTTPClient,
+    RoboMLRESPClient,
+)
 from agents.components import (
-    MLLM,
+    LLM,
+    VLM,
+    Memory,
+    SemanticRouter,
     SpeechToText,
     TextToSpeech,
-    LLM,
     Vision,
-    MapEncoding,
-    SemanticRouter,
 )
-from agents.config import TextToSpeechConfig
-from agents.clients import RoboMLHTTPClient, RoboMLRESPClient
-from agents.clients import ChromaClient
-from agents.clients import OllamaClient
-from agents.models import Whisper, SpeechT5, VisionModel, OllamaModel
+from agents.config import (
+    LLMConfig,
+    MemoryConfig,
+    SemanticRouterConfig,
+    TextToSpeechConfig,
+    VisionConfig,
+)
+from agents.models import OllamaModel, TransformersTTS, VisionModel, Whisper
+from agents.ros import FixedInput, Launcher, MemLayer, Route, Topic
 from agents.vectordbs import ChromaDB
-from agents.config import VisionConfig, LLMConfig, MapConfig, SemanticRouterConfig
-from agents.ros import Topic, Launcher, FixedInput, MapLayer, Route
 
 
-### Setup our models and vectordb ###
-whisper = Whisper(name="whisper")
-whisper_client = RoboMLHTTPClient(whisper)
-speecht5 = SpeechT5(name="speecht5")
-speecht5_client = RoboMLHTTPClient(speecht5)
-qwen_vl = OllamaModel(name="qwen_vl", checkpoint="qwen2.5vl:latest")
-qwen_client = OllamaClient(qwen_vl)
-llama = OllamaModel(name="llama", checkpoint="llama3.2:3b")
-llama_client = OllamaClient(llama)
-chroma = ChromaDB()
-chroma_client = ChromaClient(db=chroma)
+### Models and shared clients ###
+whisper_client = RoboMLHTTPClient(Whisper(name="whisper"))
+tts_client = RoboMLHTTPClient(TransformersTTS(name="tts"))
+detection_client = RoboMLRESPClient(
+    VisionModel(name="rtdetr", checkpoint="PekingU/rtdetr_r50vd_coco_o365")
+)
+qwen_vl_client = OllamaClient(
+    OllamaModel(name="qwen_vl", checkpoint="qwen2.5vl:latest")
+)
+qwen_client = OllamaClient(OllamaModel(name="qwen", checkpoint="qwen3:0.6b"))
+embedding_client = OllamaClient(
+    OllamaModel(name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest")
+)
+# ChromaDB is still used by SemanticRouter for route embeddings.
+chroma_client = ChromaClient(db=ChromaDB(), port=8080)
 
-### Setup our components ###
-# Setup a speech to text component
+
+### Speech I/O ###
 audio_in = Topic(name="audio0", msg_type="Audio")
 query_topic = Topic(name="question", msg_type="String")
+query_answer = Topic(name="answer", msg_type="String")
 
 speech_to_text = SpeechToText(
     inputs=[audio_in],
@@ -54,61 +156,62 @@ speech_to_text = SpeechToText(
     component_name="speech_to_text",
 )
 
-# Setup a text to speech component
-query_answer = Topic(name="answer", msg_type="String")
-
-t2s_config = TextToSpeechConfig(play_on_device=True)
-
 text_to_speech = TextToSpeech(
     inputs=[query_answer],
     trigger=query_answer,
-    model_client=speecht5_client,
-    config=t2s_config,
+    model_client=tts_client,
+    config=TextToSpeechConfig(play_on_device=True),
     component_name="text_to_speech",
 )
 
-# Setup a vision component for object detection
+
+### Vision (object detection) ###
 image0 = Topic(name="image_raw", msg_type="Image")
 detections_topic = Topic(name="detections", msg_type="Detections")
 
-detection_config = VisionConfig(threshold=0.5, enable_local_classifier=True)
 vision = Vision(
     inputs=[image0],
     outputs=[detections_topic],
     trigger=image0,
-    config=detection_config,
+    config=VisionConfig(threshold=0.5),
+    model_client=detection_client,
     component_name="object_detection",
 )
 
-# Define a generic mllm component for vqa
+
+### VQA VLM ###
 mllm_query = Topic(name="mllm_query", msg_type="String")
 
-mllm = MLLM(
+mllm = VLM(
     inputs=[mllm_query, image0, detections_topic],
     outputs=[query_answer],
-    model_client=qwen_client,
+    model_client=qwen_vl_client,
     trigger=mllm_query,
     component_name="visual_q_and_a",
 )
-
 mllm.set_component_prompt(
-    template="""Imagine you are a robot.
-    This image has following items: {{ detections }}.
-    Answer the following about this image: {{ text0 }}"""
+    template=(
+        "Imagine you are a robot. This image has the following items: "
+        "{{ detections }}. Answer the following about this image: {{ text0 }}"
+    )
 )
 
-# Define a fixed input mllm component that does introspection
+
+### Introspection VLM (room classification feeding the memory) ###
 introspection_query = FixedInput(
     name="introspection_query",
     msg_type="String",
-    fixed="What kind of a room is this? Is it an office, a bedroom or a kitchen? Give a one word answer, out of the given choices",
+    fixed=(
+        "What kind of a room is this? Is it an office, a bedroom or a "
+        "kitchen? Give a one word answer, out of the given choices"
+    ),
 )
 introspection_answer = Topic(name="introspection_answer", msg_type="String")
 
-introspector = MLLM(
+introspector = VLM(
     inputs=[introspection_query, image0],
     outputs=[introspection_answer],
-    model_client=qwen_client,
+    model_client=qwen_vl_client,
     trigger=15.0,
     component_name="introspector",
 )
@@ -122,88 +225,82 @@ def introspection_validation(output: str) -> Optional[str]:
 
 introspector.add_publisher_preprocessor(introspection_answer, introspection_validation)
 
-# Define a semantic map using MapEncoding component
-layer1 = MapLayer(subscribes_to=detections_topic, temporal_change=True)
-layer2 = MapLayer(subscribes_to=introspection_answer, resolution_multiple=3)
 
+### Memory (graph-backed spatio-temporal memory) ###
 position = Topic(name="odom", msg_type="Odometry")
-map_topic = Topic(name="map", msg_type="OccupancyGrid")
 
-map_conf = MapConfig(map_name="map")
-map = MapEncoding(
-    layers=[layer1, layer2],
+memory = Memory(
+    layers=[
+        MemLayer(subscribes_to=detections_topic, temporal_change=True),
+        MemLayer(subscribes_to=introspection_answer),
+    ],
     position=position,
-    map_topic=map_topic,
-    config=map_conf,
-    db_client=chroma_client,
+    model_client=qwen_client,
+    embedding_client=embedding_client,
+    config=MemoryConfig(db_path="/tmp/complete_agent.db"),
     trigger=15.0,
-    component_name="map_encoder",
+    component_name="memory",
 )
 
-# Define a generic LLM component
+
+### Generic LLM (general Q&A) ###
 llm_query = Topic(name="llm_query", msg_type="String")
 
 llm = LLM(
     inputs=[llm_query],
     outputs=[query_answer],
-    model_client=llama_client,
+    model_client=qwen_client,
     trigger=[llm_query],
     component_name="general_q_and_a",
 )
 
-# Define a Go-to-X component using LLM
+
+### Go-to-X using LLM tool calling on Memory.locate ###
 goto_query = Topic(name="goto_query", msg_type="String")
 goal_point = Topic(name="goal_point", msg_type="PoseStamped")
-
-goto_config = LLMConfig(
-    enable_rag=True,
-    collection_name="map",
-    distance_func="l2",
-    n_results=1,
-    add_metadata=True,
-)
 
 goto = LLM(
     inputs=[goto_query],
     outputs=[goal_point],
-    model_client=llama_client,
-    config=goto_config,
-    db_client=chroma_client,
+    model_client=qwen_client,
     trigger=goto_query,
+    config=LLMConfig(),
     component_name="go_to_x",
 )
-
 goto.set_component_prompt(
-    template="""From the given metadata, extract coordinates and provide
-    the coordinates in the following json format:\n {"position": coordinates}"""
+    template=(
+        "The user asks you to go to a place. Use the available tools to "
+        "look up the place's location in memory. Pass the place name to "
+        "the locate tool as the ``concept`` argument. "
+        "The user said: {{goto_query}}"
+    )
 )
+memory.register_tools_on(goto, tools=["locate"], send_tool_response_to_model=False)
 
 
-# pre-process the output before publishing to a topic of msg_type PoseStamped
-def llm_answer_to_goal_point(output: str) -> Optional[np.ndarray]:
-    # extract the json part of the output string (including brackets)
-    # one can use sophisticated regex parsing here but we'll keep it simple
-    json_string = output[output.find("{") : output.rfind("}") + 1]
-    # load the string as a json and extract position coordinates
-    # if there is an error, return None, i.e. no output would be published to goal_point
-    try:
-        json_dict = json.loads(json_string)
-        coordinates = np.fromstring(json_dict["position"], sep=",", dtype=np.float64)
-        print("Coordinates Extracted:", coordinates)
-        if coordinates.shape[0] < 2 or coordinates.shape[0] > 3:
-            return
-        elif (
-            coordinates.shape[0] == 2
-        ):  # sometimes LLMs avoid adding the zeros of z-dimension
-            coordinates = np.append(coordinates, 0)
-        return coordinates
-    except Exception:
+_LOCATION_RE = re.compile(r"Location:\s*\(([^)]+)\)")
+
+
+def locate_text_to_goal_point(output: str) -> Optional[np.ndarray]:
+    """Pull the centroid coordinates out of Memory.locate's text output."""
+    match = _LOCATION_RE.search(output)
+    if not match:
         return
+    try:
+        coords = np.fromstring(match.group(1), sep=",", dtype=np.float64)
+    except ValueError:
+        return
+    if coords.shape[0] == 2:
+        coords = np.append(coords, 0.0)
+    if coords.shape[0] != 3:
+        return
+    return coords
 
 
-goto.add_publisher_preprocessor(goal_point, llm_answer_to_goal_point)
+goto.add_publisher_preprocessor(goal_point, locate_text_to_goal_point)
 
-# Define a semantic router between a generic LLM component, VQA MLLM component and Go-to-X component
+
+### Semantic router (uses ChromaDB for the route embeddings) ###
 goto_route = Route(
     routes_to=goto_query,
     samples=[
@@ -214,7 +311,6 @@ goto_route = Route(
         "Go to hallway",
     ],
 )
-
 llm_route = Route(
     routes_to=llm_query,
     samples=[
@@ -225,7 +321,6 @@ llm_route = Route(
         "Whats up?",
     ],
 )
-
 mllm_route = Route(
     routes_to=mllm_query,
     samples=[
@@ -239,18 +334,17 @@ mllm_route = Route(
     ],
 )
 
-router_config = SemanticRouterConfig(router_name="go-to-router", distance_func="l2")
-# Initialize the router component
 router = SemanticRouter(
     inputs=[query_topic],
     routes=[llm_route, goto_route, mllm_route],
     default_route=llm_route,
-    config=router_config,
+    config=SemanticRouterConfig(router_name="go-to-router", distance_func="l2"),
     db_client=chroma_client,
     component_name="router",
 )
 
-# Launch the components
+
+### Launch (single process so goto can call memory in-process) ###
 launcher = Launcher()
 launcher.add_pkg(
     components=[
@@ -258,7 +352,7 @@ launcher.add_pkg(
         llm,
         goto,
         introspector,
-        map,
+        memory,
         router,
         speech_to_text,
         text_to_speech,
@@ -269,20 +363,20 @@ launcher.bringup()
 ```
 
 ```{note}
-Note how we use the same model for _general_q_and_a_ and _go_to_x_ components. Similarly _visual_q_and_a_ and _introspector_ components share a multimodal LLM model.
+The same `qwen_client` (Ollama, `qwen3:0.6b`) drives general Q&A, the goto tool-caller, and Memory's episodic-consolidation summaries. The VLM (`qwen_vl_client`) is shared between the VQA path and the introspector.
 ```
 
 ## What We Have Built
 
-In this single Recipe, we have assembled a fully capable embodied agent with the following capabilities:
+In this single recipe, we have assembled a fully capable embodied agent with the following capabilities:
 
 - {material-regular}`record_voice_over;1.2em;sd-text-primary` **A conversational interface** using speech-to-text and text-to-speech models that uses the robot's microphone and playback speaker. (See: [Conversational Agent](conversational-agent.md))
 - {material-regular}`visibility;1.2em;sd-text-primary` **Contextual visual question answering** based on the robot's camera, using a multimodal LLM enriched with object detection output. (See: [Prompt Engineering](prompt-engineering.md))
 - {material-regular}`chat;1.2em;sd-text-primary` **General knowledge Q&A** using a text-only LLM for non-visual queries.
-- {material-regular}`map;1.2em;sd-text-primary` **A spatio-temporal semantic map** that acts as the robot's long-term memory, continuously updated with object detections and room-type introspection. (See: [Semantic Map](semantic-map.md))
-- {material-regular}`route;1.2em;sd-text-primary` **RAG-powered Go-to-X navigation** that retrieves coordinates from the semantic map and publishes goal points to the navigation stack. (See: [GoTo Navigation](goto-navigation.md))
+- {material-regular}`memory;1.2em;sd-text-primary` **A graph-backed spatio-temporal memory** that acts as the robot's long-term memory, continuously updated with object detections and room-type introspection, indexed simultaneously by meaning, location, and time. Built on [eMEM](https://github.com/automatika-robotics/emem). (See: [Spatio-Temporal Memory](semantic-map.md))
+- {material-regular}`route;1.2em;sd-text-primary` **Memory-aware Go-to-X navigation** -- a tool-calling LLM that asks Memory to `locate` a place and publishes the result as a goal point. (See: [GoTo Navigation](goto-navigation.md), [Tool Calling](tool-calling.md))
 - {material-regular}`alt_route;1.2em;sd-text-primary` **Intent-based semantic routing** through a single input interface that directs queries to the correct component based on content. (See: [Semantic Routing](semantic-routing.md))
 
-This is the EMOS developer experience: a sophisticated, multi-capability embodied agent defined entirely in a single Python script. Every component -- perception, reasoning, memory, navigation, and speech -- is wired together through Topics and launched with one call to `bringup()`. The same Recipe runs on any robot that EMOS supports, from wheeled AMRs to quadrupeds, without modification.
+This is the EMOS developer experience: a sophisticated, multi-capability embodied agent defined entirely in a single Python script. Every component -- perception, reasoning, memory, navigation, and speech -- is wired together through Topics and launched with one call to `bringup()`. The same recipe runs on any robot that EMOS supports, from wheeled AMRs to quadrupeds, without modification.
 
-To add runtime resilience -- fallback logic, recovery maneuvers, algorithm switching -- see the [Events & Actions](../../concepts/events-and-actions.md) documentation.
+To run this same graph in **multi-process mode with fault tolerance**, see [Multiprocessing & Fault Tolerance](../events-and-resilience/multiprocessing.md). For runtime resilience -- fallback logic, recovery maneuvers, algorithm switching -- see the [Events & Actions](../../concepts/events-and-actions.md) documentation.

--- a/docs/recipes/foundation/complete-agent.md
+++ b/docs/recipes/foundation/complete-agent.md
@@ -5,7 +5,7 @@ This is the capstone recipe. Everything we have built in the previous tutorials 
 This is what EMOS is designed for. Instead of stitching together dozens of ROS nodes, launch files, and custom middleware, you define a complete agentic workflow as a graph of [Components](../../intelligence/ai-components.md) connected through [Topics](../../concepts/topics.md), and bring it up with a single call. The result is a robot that can listen, see, think, remember, navigate, and speak -- all orchestrated by EMOS.
 
 ```{seealso}
-For the multiprocessing-and-fault-tolerant variant of this recipe, see [Multiprocessing & Fault Tolerance](../events-and-resilience/multiprocessing.md). For the agentic-harness variant where a single [Cortex](../../intelligence/cortex.md) component takes charge of an entire graph like this, see [Memory and Cortex](../planning-and-manipulation/cortex-memory.md) and [Embodied Reasoning with Cortex](../planning-and-manipulation/cortex-navigation.md).
+For the multiprocessing-and-fault-tolerant variant of this recipe, see [Multiprocessing & Fault Tolerance](../events-and-resilience/multiprocessing.md). For the agentic-harness variant where a single [Cortex](../../intelligence/cortex.md) component takes charge of an entire graph like this, see [Memory and Cortex](../planning-and-manipulation/cortex-memory.md) and [Cortex Driving the Full Stack](../planning-and-manipulation/cortex-navigation.md).
 ```
 
 ```{admonition} Prerequisites

--- a/docs/recipes/foundation/complete-agent.md
+++ b/docs/recipes/foundation/complete-agent.md
@@ -192,7 +192,8 @@ mllm = VLM(
 mllm.set_component_prompt(
     template=(
         "Imagine you are a robot. This image has the following items: "
-        "{{ detections }}. Answer the following about this image: {{ text0 }}"
+        "{{ detections }}. Answer the following about this image: "
+        "{{ mllm_query }}"
     )
 )
 
@@ -231,7 +232,7 @@ position = Topic(name="odom", msg_type="Odometry")
 
 memory = Memory(
     layers=[
-        MemLayer(subscribes_to=detections_topic, temporal_change=True),
+        MemLayer(subscribes_to=detections_topic),
         MemLayer(subscribes_to=introspection_answer),
     ],
     position=position,
@@ -329,7 +330,7 @@ mllm_route = Route(
         "Whats in front of you?",
         "Where are we",
         "Do you see any people?",
-        "How many things are infront of you?",
+        "How many things are in front of you?",
         "Is this room occupied?",
     ],
 )

--- a/docs/recipes/foundation/conversational-agent.md
+++ b/docs/recipes/foundation/conversational-agent.md
@@ -32,7 +32,7 @@ from agents.config import SpeechToTextConfig
 audio_in = Topic(name="audio0", msg_type="Audio")
 text_query = Topic(name="text0", msg_type="String")
 
-s2t_config = SpeechToTextConfig(enable_vad=True,     # option to listen for speech through the microphone, set to False if usign web UI
+s2t_config = SpeechToTextConfig(enable_vad=True,     # option to listen for speech through the microphone, set to False if using web UI
                                 enable_wakeword=True) # option to invoke the component with a wakeword like 'hey jarvis', set to False if using web UI
 ```
 
@@ -97,7 +97,7 @@ text_answer = Topic(name="text1", msg_type="String")
 qwen_vl = OllamaModel(name="qwen_vl", checkpoint="qwen2.5vl:latest")
 qwen_client = OllamaClient(qwen_vl)
 
-mllm_config = VLMConfig(stream=True)  # Other inference specific paramters can be provided here
+mllm_config = VLMConfig(stream=True)  # Other inference specific parameters can be provided here
 
 # Define an VLM component
 mllm = VLM(
@@ -183,7 +183,7 @@ text_query = Topic(name="text0", msg_type="String")
 whisper = Whisper(name="whisper")  # Custom model init params can be provided here
 roboml_whisper = RoboMLWSClient(whisper)
 
-s2t_config = SpeechToTextConfig(enable_vad=True,     # option to listen for speech through the microphone, set to False if usign web UI
+s2t_config = SpeechToTextConfig(enable_vad=True,     # option to listen for speech through the microphone, set to False if using web UI
                                 enable_wakeword=True) # option to invoke the component with a wakeword like 'hey jarvis', set to False if using web UI
 
 speech_to_text = SpeechToText(
@@ -200,7 +200,7 @@ text_answer = Topic(name="text1", msg_type="String")
 
 qwen_vl = OllamaModel(name="qwen_vl", checkpoint="qwen2.5vl:latest")
 qwen_client = OllamaClient(qwen_vl)
-mllm_config = VLMConfig(stream=True)  # Other inference specific paramters can be provided here
+mllm_config = VLMConfig(stream=True)  # Other inference specific parameters can be provided here
 
 mllm = VLM(
     inputs=[text_query, image0],

--- a/docs/recipes/foundation/conversational-agent.md
+++ b/docs/recipes/foundation/conversational-agent.md
@@ -122,7 +122,7 @@ Notice that the template is a jinja2 template string, where the actual name of t
 
 ## TextToSpeech Component
 
-The TextToSpeech component setup will be very similar to the SpeechToText component. We will once again use a RoboML client, this time with the SpeechT5 model (opensource model from Microsoft). Furthermore, this component can be configured to play audio on a playback device available onboard the robot. We will utilize this option through our config. An output topic is optional for this component as we will be playing the audio directly on device.
+The TextToSpeech component setup will be very similar to the SpeechToText component. We will once again use a RoboML client, this time with the unified `TransformersTTS` wrapper. RoboML serves any HuggingFace Transformers TTS model -- VITS, Bark, SpeechT5, SeamlessM4T, etc. -- through a single class; here we keep the default checkpoint, [Facebook's MMS-TTS-eng (VITS)](https://huggingface.co/facebook/mms-tts-eng), which is fast and lightweight enough to run comfortably on-device. The component can be configured to play audio on a playback device available onboard the robot, which we will utilize through our config. An output topic is optional for this component as we will be playing the audio directly on device.
 
 ```{note}
 In order to utilize _play_on_device_ you need to install a couple of dependencies as follows: `pip install soundfile sounddevice`
@@ -130,7 +130,7 @@ In order to utilize _play_on_device_ you need to install a couple of dependencie
 
 ```python
 from agents.config import TextToSpeechConfig
-from agents.models import SpeechT5
+from agents.models import TransformersTTS
 
 # config for asynchronously playing audio on device
 t2s_config = TextToSpeechConfig(play_on_device=True, stream=True)  # Set play_on_device to false if using the web UI
@@ -138,13 +138,13 @@ t2s_config = TextToSpeechConfig(play_on_device=True, stream=True)  # Set play_on
 # Uncomment the following line for receiving output on the web UI
 # audio_out = Topic(name="audio_out", msg_type="Audio")
 
-speecht5 = SpeechT5(name="speecht5")
-roboml_speecht5 = RoboMLWSClient(speecht5)
+vits = TransformersTTS(name="vits")  # default checkpoint: facebook/mms-tts-eng
+roboml_vits = RoboMLWSClient(vits)
 text_to_speech = TextToSpeech(
     inputs=[text_answer],
     outputs=[],  # use outputs=[audio_out] for receiving answers on web UI
     trigger=text_answer,
-    model_client=roboml_speecht5,
+    model_client=roboml_vits,
     config=t2s_config,
     component_name="text_to_speech"
 )
@@ -174,7 +174,7 @@ Et voila! We have setup a graph of three components in less than 50 lines of wel
 from agents.components import VLM, SpeechToText, TextToSpeech
 from agents.config import SpeechToTextConfig, TextToSpeechConfig, VLMConfig
 from agents.clients import OllamaClient, RoboMLWSClient
-from agents.models import Whisper, SpeechT5, OllamaModel
+from agents.models import Whisper, TransformersTTS, OllamaModel
 from agents.ros import Topic, Launcher
 
 audio_in = Topic(name="audio0", msg_type="Audio")
@@ -216,13 +216,13 @@ t2s_config = TextToSpeechConfig(play_on_device=True, stream=True)  # Set play_on
 # Uncomment the following line for receiving output on the web UI
 # audio_out = Topic(name="audio_out", msg_type="Audio")
 
-speecht5 = SpeechT5(name="speecht5")
-roboml_speecht5 = RoboMLWSClient(speecht5)
+vits = TransformersTTS(name="vits")  # default checkpoint: facebook/mms-tts-eng
+roboml_vits = RoboMLWSClient(vits)
 text_to_speech = TextToSpeech(
     inputs=[text_answer],
     outputs=[],  # use outputs=[audio_out] for receiving answers on web UI
     trigger=text_answer,
-    model_client=roboml_speecht5,
+    model_client=roboml_vits,
     config=t2s_config,
     component_name="text_to_speech"
 )

--- a/docs/recipes/foundation/goto-navigation.md
+++ b/docs/recipes/foundation/goto-navigation.md
@@ -1,204 +1,281 @@
 # GoTo Navigation
 
-In the previous [recipe](semantic-map.md) we created a semantic map using the MapEncoding component. Intuitively one can imagine that using the map data would require some form of RAG. Let us suppose that we want to create a Go-to-X component, which, when given a command like 'Go to the yellow door', would retrieve the coordinates of the _yellow door_ from the map and publish them to a goal point topic of type _PoseStamped_ to be handled by our robot's [navigation system](../../navigation/overview.md). We will create our Go-to-X component using the LLM [component](../../intelligence/ai-components.md) provided by EMOS. We will start by initializing the component, and configuring it to use RAG.
+In the previous [recipe](semantic-map.md) we built a graph-backed spatio-temporal memory using the `Memory` component. Memory tags every observation with the robot's pose, so for any concept the agent has encountered (an object class, a room label) we can ask Memory: *where did we see this?* It already exposes that lookup as a component action called `locate`, returning a centroid plus a radius for the most likely region.
 
-## Initialize the component
+In this recipe we wire `locate` into a Go-to-X component so that a command like *"Go to the kitchen"* turns into a `PoseStamped` goal point that the navigation stack can consume. We do this by **registering Memory's `locate` tool on an LLM** -- the LLM decides when to call the tool, Memory answers, and a small preprocessor converts the textual answer into a numpy coordinate that gets published as the goal.
+
+```{seealso}
+For the conceptual reference of Memory's full retrieval surface, see the [Memory page](../../intelligence/memory.md). For a generic introduction to LLM tool calling that is not tied to navigation, see the next recipe, [Tool Calling](tool-calling.md).
+```
+
+```{admonition} Prerequisites
+:class: important
+
+Memory needs the [eMEM](https://github.com/automatika-robotics/emem) package: `pip install emem`.
+```
+
+---
+
+## What we're building
+
+Three components in a single launcher:
+
+| Component | Role |
+|---|---|
+| **Vision** | Object detector publishing `Detections` per frame. Feeds Memory. |
+| **Memory** | Graph-backed spatio-temporal memory ingesting detections; tags each observation with the robot's pose from `/odom`. |
+| **goto LLM** | A plain `LLM` component that takes a free-form *"go to X"* query, calls Memory's `locate` tool to look up the place, and publishes the resulting coordinates on `goal_point`. |
+
+Memory's `locate` returns a textual answer like `"... Location: (10.3, 9.8, 0.0) ..."` (centroid plus a description). We wire a small regex preprocessor onto the goto LLM's output topic that picks the centroid out and converts it to an `np.ndarray`, which the framework publishes as the `PoseStamped` goal point.
+
+---
+
+## Step 1: Vision and Memory
+
+```python
+from agents.clients import OllamaClient, RoboMLRESPClient
+from agents.components import Memory, Vision
+from agents.config import MemoryConfig, VisionConfig
+from agents.models import OllamaModel, VisionModel
+from agents.ros import Launcher, MemLayer, Topic
+
+image0 = Topic(name="image_raw", msg_type="Image")
+detections_topic = Topic(name="detections", msg_type="Detections")
+position = Topic(name="odom", msg_type="Odometry")
+
+vision = Vision(
+    inputs=[image0],
+    outputs=[detections_topic],
+    trigger=image0,
+    config=VisionConfig(threshold=0.5),
+    model_client=RoboMLRESPClient(
+        VisionModel(name="rtdetr", checkpoint="PekingU/rtdetr_r50vd_coco_o365")
+    ),
+    component_name="vision",
+)
+
+embedding_client = OllamaClient(
+    OllamaModel(name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest")
+)
+
+memory = Memory(
+    layers=[MemLayer(subscribes_to=detections_topic, temporal_change=True)],
+    position=position,
+    embedding_client=embedding_client,
+    config=MemoryConfig(db_path="/tmp/go_to_x.db"),
+    trigger=10.0,
+    component_name="memory",
+)
+```
+
+Each detection becomes an `ObservationNode` in Memory tagged with the robot's pose at the moment the detection was made. After a few minutes of accumulation, eMEM's entity layer auto-merges nearby semantically-similar detections into persistent entities, and `locate("chair")` returns the centroid of the merged "chair" entity.
+
+---
+
+## Step 2: The Go-to-X LLM
 
 ```python
 from agents.components import LLM
-from agents.models import OllamaModel
 from agents.config import LLMConfig
-from agents.clients import OllamaClient
-from agents.ros import Launcher, Topic
 
-# Start a Llama3.2 based llm component using ollama client
-llama = OllamaModel(name="llama", checkpoint="llama3.2:3b")
-llama_client = OllamaClient(llama)
+qwen = OllamaModel(name="qwen", checkpoint="qwen3.5:latest")
+qwen_client = OllamaClient(qwen)
 
-# Define LLM input and output topics including goal_point topic of type PoseStamped
 goto_in = Topic(name="goto_in", msg_type="String")
 goal_point = Topic(name="goal_point", msg_type="PoseStamped")
-```
 
-In order to configure the component to use RAG, we will set the following options in its config.
-
-```python
-config = LLMConfig(enable_rag=True,
-                   collection_name="map",
-                   distance_func="l2",
-                   n_results=1,
-                   add_metadata=True)
-```
-
-Note that the _collection_name_ parameter is the same as the map name we set in the previous [recipe](semantic-map.md). We have also set _add_metadata_ parameter to true to make sure that our metadata is included in the RAG result, as the spatial coordinates we want to get are part of the metadata. Let us have a quick look at the metadata stored in the map by the MapEncoding component.
-
-```
-{
-    "coordinates": [1.1, 2.2, 0.0],
-    "layer_name": "Topic_Name",  # same as topic name that the layer is subscribed to
-    "timestamp": 1234567,
-    "temporal_change": True
-}
-```
-
-With this information, we will first initialize our component.
-
-```{caution}
-In the following code block we are using the same DB client that was setup in the [Semantic Map](semantic-map.md) recipe.
-```
-
-```python
-# initialize the component
 goto = LLM(
     inputs=[goto_in],
     outputs=[goal_point],
-    model_client=llama_client,
-    db_client=chroma_client,  # check the previous example where we setup this database client
+    model_client=qwen_client,
     trigger=goto_in,
-    config=config,
-    component_name='go_to_x'
+    config=LLMConfig(),
+    component_name="go_to_x",
 )
-```
 
-## Pre-process the model output before publishing
-
-Knowing that the output of retrieval will be appended to the beginning of our query as context, we will setup a component level prompt for our LLM.
-
-```python
-# set a component prompt
 goto.set_component_prompt(
-    template="""From the given metadata, extract coordinates and provide
-    the coordinates in the following json format:\n {"position": coordinates}"""
+    template=(
+        "The user asks you to go to a place. Use the available tools to "
+        "look up the place's location in memory. Pass the place name to "
+        "the locate tool as the ``concept`` argument. User said: {{goto_in}}"
+    )
 )
 ```
 
-```{note}
-One might notice that we have not used an input topic name in our prompt. This is because we only need the input topic to fetch data from the vector DB during the RAG step. The query to the LLM in this case would only be composed of data fetched from the DB and our prompt.
-```
+---
 
-As the LLM output will contain text other than the _json_ string that we have asked for, we need to add a pre-processing function to the output topic that extracts the required part of the text and returns the output in a format that can be published to a _PoseStamped_ topic, i.e. a numpy array of floats.
+## Step 3: Register Memory's `locate` tool on the LLM
 
 ```python
+memory.register_tools_on(goto, tools=["locate"], send_tool_response_to_model=False)
+```
+
+`register_tools_on` exposes Memory's component actions to the goto LLM as callable tools. We register a single tool, `locate`, since the LLM only needs the lookup capability for this recipe. The flag `send_tool_response_to_model=False` is what makes the recipe end-to-end: instead of feeding `locate`'s answer back into the LLM for a follow-up generation, the answer becomes the *output of the LLM component*. After preprocessing, that output is what gets published on `goal_point`.
+
+---
+
+## Step 4: Parse Memory's textual answer into coordinates
+
+`locate` returns text formatted like:
+
+```
+Concept: kitchen
+Location: (10.32, 9.84, 0.0)
+Confidence: 0.91
+Radius: 1.45m
+...
+```
+
+We register a small preprocessor on the `goal_point` output topic that pulls the centroid out of that text and converts it to an `np.ndarray`. The framework then publishes the array as a `PoseStamped`.
+
+```python
+import re
 from typing import Optional
-import json
+
 import numpy as np
 
-# pre-process the output before publishing to a topic of msg_type PoseStamped
-def llm_answer_to_goal_point(output: str) -> Optional[np.ndarray]:
-    # extract the json part of the output string (including brackets)
-    # one can use sophisticated regex parsing here but we'll keep it simple
-    json_string = output[output.find("{") : output.rfind("}") + 1]
-    # load the string as a json and extract position coordinates
-    # if there is an error, return None, i.e. no output would be published to goal_point
-    try:
-        json_dict = json.loads(json_string)
-        coordinates = np.fromstring(json_dict["position"], sep=',', dtype=np.float64)
-        print('Coordinates Extracted:', coordinates)
-        if coordinates.shape[0] < 2 or coordinates.shape[0] > 3:
-            return
-        elif coordinates.shape[0] == 2:  # sometimes LLMs avoid adding the zeros of z-dimension
-            coordinates = np.append(coordinates, 0)
-        return coordinates
-    except Exception:
-        return
+_LOCATION_RE = re.compile(r"Location:\s*\(([^)]+)\)")
 
-# add the pre-processing function to the goal_point output topic
-goto.add_publisher_preprocessor(goal_point, llm_answer_to_goal_point)
+
+def locate_text_to_goal_point(output: str) -> Optional[np.ndarray]:
+    """Pull the centroid coordinates out of Memory.locate's text output."""
+    match = _LOCATION_RE.search(output)
+    if not match:
+        return  # no match → nothing to publish
+    try:
+        coords = np.fromstring(match.group(1), sep=",", dtype=np.float64)
+    except ValueError:
+        return
+    if coords.shape[0] == 2:
+        coords = np.append(coords, 0.0)
+    if coords.shape[0] != 3:
+        return
+    return coords
+
+
+goto.add_publisher_preprocessor(goal_point, locate_text_to_goal_point)
 ```
 
-## Launching the Components
+If the LLM (correctly) called `locate`, the regex matches, the coordinates parse cleanly, and the goal point is published. If the LLM hallucinated or the place is unknown to Memory, the preprocessor returns `None` and **nothing is published** -- the navigation stack sees no spurious goal.
 
-And we will launch our Go-to-X component.
+---
+
+## Step 5: Launch
 
 ```python
-from agents.ros import Launcher
-
-# Launch the component
 launcher = Launcher()
-launcher.add_pkg(
-    components=[goto]
-    )
+launcher.add_pkg(components=[vision, memory, goto])
 launcher.bringup()
 ```
 
-And that is all. Our Go-to-X component is ready. The complete code for this recipe is given below:
+---
+
+## Full recipe code
 
 ```{code-block} python
-:caption: Go-to-X Component
+:caption: Go-to-X with Memory tool calling
 :linenos:
+import re
 from typing import Optional
-import json
+
 import numpy as np
-from agents.components import LLM
-from agents.models import OllamaModel
-from agents.vectordbs import ChromaDB
-from agents.config import LLMConfig
-from agents.clients import ChromaClient, OllamaClient
-from agents.ros import Launcher, Topic
 
-# Start a Llama3.2 based llm component using ollama client
-llama = OllamaModel(name="llama", checkpoint="llama3.2:3b")
-llama_client = OllamaClient(llama)
+from agents.clients import OllamaClient, RoboMLRESPClient
+from agents.components import LLM, Memory, Vision
+from agents.config import LLMConfig, MemoryConfig, VisionConfig
+from agents.models import OllamaModel, VisionModel
+from agents.ros import Launcher, MemLayer, Topic
 
-# Initialize a vector DB that will store our routes
-chroma = ChromaDB()
-chroma_client = ChromaClient(db=chroma)
 
-# Define LLM input and output topics including goal_point topic of type PoseStamped
+# -- Perception side: vision + memory --
+image0 = Topic(name="image_raw", msg_type="Image")
+detections_topic = Topic(name="detections", msg_type="Detections")
+position = Topic(name="odom", msg_type="Odometry")
+
+vision = Vision(
+    inputs=[image0],
+    outputs=[detections_topic],
+    trigger=image0,
+    config=VisionConfig(threshold=0.5),
+    model_client=RoboMLRESPClient(
+        VisionModel(name="rtdetr", checkpoint="PekingU/rtdetr_r50vd_coco_o365")
+    ),
+    component_name="vision",
+)
+
+embedding_client = OllamaClient(
+    OllamaModel(name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest")
+)
+
+memory = Memory(
+    layers=[MemLayer(subscribes_to=detections_topic, temporal_change=True)],
+    position=position,
+    embedding_client=embedding_client,
+    config=MemoryConfig(db_path="/tmp/go_to_x.db"),
+    trigger=10.0,
+    component_name="memory",
+)
+
+
+# -- Go-to-X LLM --
+qwen = OllamaModel(name="qwen", checkpoint="qwen3.5:latest")
+qwen_client = OllamaClient(qwen)
+
 goto_in = Topic(name="goto_in", msg_type="String")
 goal_point = Topic(name="goal_point", msg_type="PoseStamped")
 
-config = LLMConfig(enable_rag=True,
-                   collection_name="map",
-                   distance_func="l2",
-                   n_results=1,
-                   add_metadata=True)
-
-# initialize the component
 goto = LLM(
     inputs=[goto_in],
     outputs=[goal_point],
-    model_client=llama_client,
-    db_client=chroma_client,  # check the previous example where we setup this database client
+    model_client=qwen_client,
     trigger=goto_in,
-    config=config,
-    component_name='go_to_x'
+    config=LLMConfig(),
+    component_name="go_to_x",
 )
 
-# set a component prompt
 goto.set_component_prompt(
-    template="""From the given metadata, extract coordinates and provide
-    the coordinates in the following json format:\n {"position": coordinates}"""
+    template=(
+        "The user asks you to go to a place. Use the available tools to "
+        "look up the place's location in memory. Pass the place name to "
+        "the locate tool as the ``concept`` argument. User said: {{goto_in}}"
+    )
 )
 
+memory.register_tools_on(goto, tools=["locate"], send_tool_response_to_model=False)
 
-# pre-process the output before publishing to a topic of msg_type PoseStamped
-def llm_answer_to_goal_point(output: str) -> Optional[np.ndarray]:
-    # extract the json part of the output string (including brackets)
-    # one can use sophisticated regex parsing here but we'll keep it simple
-    json_string = output[output.find("{") : output.rfind("}") + 1]
-    # load the string as a json and extract position coordinates
-    # if there is an error, return None, i.e. no output would be published to goal_point
-    try:
-        json_dict = json.loads(json_string)
-        coordinates = np.fromstring(json_dict["position"], sep=',', dtype=np.float64)
-        print('Coordinates Extracted:', coordinates)
-        if coordinates.shape[0] < 2 or coordinates.shape[0] > 3:
-            return
-        elif coordinates.shape[0] == 2:  # sometimes LLMs avoid adding the zeros of z-dimension
-            coordinates = np.append(coordinates, 0)
-        return coordinates
-    except Exception:
+
+_LOCATION_RE = re.compile(r"Location:\s*\(([^)]+)\)")
+
+
+def locate_text_to_goal_point(output: str) -> Optional[np.ndarray]:
+    """Pull the centroid coordinates out of Memory.locate's text output."""
+    match = _LOCATION_RE.search(output)
+    if not match:
         return
+    try:
+        coords = np.fromstring(match.group(1), sep=",", dtype=np.float64)
+    except ValueError:
+        return
+    if coords.shape[0] == 2:
+        coords = np.append(coords, 0.0)
+    if coords.shape[0] != 3:
+        return
+    return coords
 
 
-# add the pre-processing function to the goal_point output topic
-goto.add_publisher_preprocessor(goal_point, llm_answer_to_goal_point)
+goto.add_publisher_preprocessor(goal_point, locate_text_to_goal_point)
 
-# Launch the component
+
+# -- Launch (single process so the LLM can call Memory in-process) --
 launcher = Launcher()
-launcher.add_pkg(
-    components=[goto]
-    )
+launcher.add_pkg(components=[vision, memory, goto])
 launcher.bringup()
 ```
+
+---
+
+## Where next
+
+- {doc}`Tool Calling <tool-calling>` — generalises this pattern. Instead of registering Memory's pre-defined tools, write your own Python function as a custom tool and register it with `goto.register_tool(...)`.
+- {doc}`Complete Agent <complete-agent>` — drops this Go-to-X pattern into a full multi-modal agent (speech I/O + vision + memory + Q&A + routing) defined in one Python script.
+- {doc}`Embodied Reasoning with Cortex <../planning-and-manipulation/cortex-navigation>` — the agentic-harness version: drop a [Cortex](../../intelligence/cortex.md) component on top of Memory and the navigation stack and the robot handles compound natural-language goals like *"go to the kitchen and tell me what's on the counter"* with no orchestration code from you.

--- a/docs/recipes/foundation/goto-navigation.md
+++ b/docs/recipes/foundation/goto-navigation.md
@@ -278,4 +278,4 @@ launcher.bringup()
 
 - {doc}`Tool Calling <tool-calling>` — generalises this pattern. Instead of registering Memory's pre-defined tools, write your own Python function as a custom tool and register it with `goto.register_tool(...)`.
 - {doc}`Complete Agent <complete-agent>` — drops this Go-to-X pattern into a full multi-modal agent (speech I/O + vision + memory + Q&A + routing) defined in one Python script.
-- {doc}`Embodied Reasoning with Cortex <../planning-and-manipulation/cortex-navigation>` — the agentic-harness version: drop a [Cortex](../../intelligence/cortex.md) component on top of Memory and the navigation stack and the robot handles compound natural-language goals like *"go to the kitchen and tell me what's on the counter"* with no orchestration code from you.
+- {doc}`Cortex Driving the Full Stack <../planning-and-manipulation/cortex-navigation>` — the agentic-harness version: drop a [Cortex](../../intelligence/cortex.md) component on top of Memory and the navigation stack and the robot handles compound natural-language goals like *"go to the kitchen and tell me what's on the counter"* with no orchestration code from you.

--- a/docs/recipes/foundation/goto-navigation.md
+++ b/docs/recipes/foundation/goto-navigation.md
@@ -59,7 +59,7 @@ embedding_client = OllamaClient(
 )
 
 memory = Memory(
-    layers=[MemLayer(subscribes_to=detections_topic, temporal_change=True)],
+    layers=[MemLayer(subscribes_to=detections_topic)],
     position=position,
     embedding_client=embedding_client,
     config=MemoryConfig(db_path="/tmp/go_to_x.db"),
@@ -119,11 +119,12 @@ memory.register_tools_on(goto, tools=["locate"], send_tool_response_to_model=Fal
 `locate` returns text formatted like:
 
 ```
-Concept: kitchen
-Location: (10.32, 9.84, 0.0)
-Confidence: 0.91
-Radius: 1.45m
-...
+Location: (10.3, 9.8, 0.0)
+Radius: 1.5m
+Based on: 5 memories (3x detections, 2x scene)
+  [detections] kitchen counter with cups and a kettle...
+  [scene] open kitchen area near the pantry...
+  [detections] kitchen island with stools...
 ```
 
 We register a small preprocessor on the `goal_point` output topic that pulls the centroid out of that text and converts it to an `np.ndarray`. The framework then publishes the array as a `PoseStamped`.
@@ -208,7 +209,7 @@ embedding_client = OllamaClient(
 )
 
 memory = Memory(
-    layers=[MemLayer(subscribes_to=detections_topic, temporal_change=True)],
+    layers=[MemLayer(subscribes_to=detections_topic)],
     position=position,
     embedding_client=embedding_client,
     config=MemoryConfig(db_path="/tmp/go_to_x.db"),

--- a/docs/recipes/foundation/index.md
+++ b/docs/recipes/foundation/index.md
@@ -30,25 +30,25 @@ Run LLMs, VLMs, STT, and TTS entirely on-device — no server required.
 Shape agent behavior with dynamic Jinja2 templates at the topic or component level.
 :::
 
-:::{grid-item-card} {material-regular}`map;1.2em;sd-text-primary` Semantic Map
+:::{grid-item-card} {material-regular}`memory;1.2em;sd-text-primary` Spatio-Temporal Memory
 :link: semantic-map
 :link-type: doc
 
-Give your robot spatio-temporal memory backed by a Vector DB.
+Give your robot a graph-backed spatio-temporal memory built on [eMEM](https://github.com/automatika-robotics/emem) -- indexed simultaneously by meaning, location, and time.
 :::
 
 :::{grid-item-card} {material-regular}`near_me;1.2em;sd-text-primary` GoTo Navigation
 :link: goto-navigation
 :link-type: doc
 
-Navigate to locations from natural language commands.
+Turn *"go to the kitchen"* into a `PoseStamped` goal -- an LLM with Memory tools, plus a regex preprocessor.
 :::
 
 :::{grid-item-card} {material-regular}`build;1.2em;sd-text-primary` Tool Calling
 :link: tool-calling
 :link-type: doc
 
-Give the LLM access to executable functions so it can act on the world.
+Generalise the tool calling pattern: write your own Python function as the LLM's tool, with full control over the schema and the published output.
 :::
 
 :::{grid-item-card} {material-regular}`alt_route;1.2em;sd-text-primary` Semantic Routing

--- a/docs/recipes/foundation/prompt-engineering.md
+++ b/docs/recipes/foundation/prompt-engineering.md
@@ -1,9 +1,9 @@
 # Prompt Engineering
 
-In this recipe we will use the output of an object detection component to enrich the prompt of a VLM (MLLM) component. Let us start by importing the components.
+In this recipe we will use the output of an object detection component to enrich the prompt of a VLM component. Let us start by importing the components.
 
 ```python
-from agents.components import Vision, MLLM
+from agents.components import Vision, VLM
 ```
 
 ## Setting up the Object Detection Component
@@ -19,14 +19,14 @@ image0 = Topic(name="image_raw", msg_type="Image")
 detections_topic = Topic(name="detections", msg_type="Detections")
 ```
 
-Additionally the component requires a model client with an object detection model. We will use the RESP client for RoboML and use the VisionModel, a convenient model class made available in EMOS for initializing all vision models available in the opensource [mmdetection](https://github.com/open-mmlab/mmdetection) library. We will specify the model we want to use by specifying the checkpoint attribute.
+Additionally the component requires a model client with an object detection model. We will use the RESP client for RoboML and the `VisionModel` wrapper, which initialises any [HuggingFace Transformers object detection model](https://huggingface.co/models?pipeline_tag=object-detection) (RT-DETR, DETR, Grounding DINO, YOLOS, ...) by checkpoint name. We pick the RT-DETR checkpoint pretrained on COCO + Objects365.
 
 ```{note}
-Learn about setting up RoboML with vision [here](https://github.com/automatika-robotics/roboml/blob/main/README.md#for-vision-models-support).
+Learn about setting up RoboML with vision [here](https://github.com/automatika-robotics/roboml/blob/main/README.md#vision-model-support).
 ```
 
 ```{seealso}
-Checkout all available mmdetection models and their benchmarking results in the [mmdetection model zoo](https://github.com/open-mmlab/mmdetection?tab=readme-ov-file#overview-of-benchmark-and-model-zoo).
+Browse all supported detection models on the [HuggingFace object-detection page](https://huggingface.co/models?pipeline_tag=object-detection).
 ```
 
 ```python
@@ -36,7 +36,7 @@ from agents.config import VisionConfig
 
 # Add an object detection model
 object_detection = VisionModel(name="object_detection",
-                               checkpoint="dino-4scale_r50_8xb2-12e_coco")
+                               checkpoint="PekingU/rtdetr_r50vd_coco_o365")
 roboml_detection = RoboMLRESPClient(object_detection)
 
 # Initialize the Vision component
@@ -55,14 +55,14 @@ vision = Vision(
 Notice that we passed in an optional config to the component. Component configs can be used to setup various parameters in the component. If the component calls an ML model then inference parameters for the model can be set in the component config.
 ```
 
-## Setting up the MLLM Component
+## Setting up the VLM Component
 
-For the MLLM component, we will provide an additional text input topic, which will listen to our queries. The output of the component will be another text topic. We will use the RoboML HTTP client with the multimodal LLM Idefics2 by the good folks at HuggingFace for this example.
+For the VLM component, we will provide an additional text input topic, which will listen to our queries. The output of the component will be another text topic. We will use the RoboML HTTP client with the multimodal LLM Idefics2 by the good folks at HuggingFace for this example.
 
 ```python
 from agents.models import TransformersMLLM
 
-# Define MLLM input and output text topics
+# Define VLM input and output text topics
 text_query = Topic(name="text0", msg_type="String")
 text_answer = Topic(name="text1", msg_type="String")
 
@@ -70,10 +70,10 @@ text_answer = Topic(name="text1", msg_type="String")
 idefics = TransformersMLLM(name="idefics_model", checkpoint="HuggingFaceM4/idefics2-8b")
 idefics_client = RoboMLHTTPClient(idefics)
 
-# Define an MLLM component
+# Define a VLM component
 # We can pass in the detections topic which we defined previously directly as an optional input
-# to the MLLM component in addition to its other required inputs
-mllm = MLLM(
+# to the VLM component in addition to its other required inputs
+mllm = VLM(
     inputs=[text_query, image0, detections_topic],
     outputs=[text_answer],
     model_client=idefics_client,
@@ -116,7 +116,7 @@ And there we have it. Complete code of this example is provided below.
 ```{code-block} python
 :caption: Prompt Engineering with Object Detection
 :linenos:
-from agents.components import Vision, MLLM
+from agents.components import Vision, VLM
 from agents.models import VisionModel, TransformersMLLM
 from agents.clients import RoboMLRESPClient, RoboMLHTTPClient
 from agents.ros import Topic, Launcher
@@ -126,7 +126,7 @@ image0 = Topic(name="image_raw", msg_type="Image")
 detections_topic = Topic(name="detections", msg_type="Detections")
 
 object_detection = VisionModel(
-    name="object_detection", checkpoint="dino-4scale_r50_8xb2-12e_coco"
+    name="object_detection", checkpoint="PekingU/rtdetr_r50vd_coco_o365"
 )
 roboml_detection = RoboMLRESPClient(object_detection)
 
@@ -146,7 +146,7 @@ text_answer = Topic(name="text1", msg_type="String")
 idefics = TransformersMLLM(name="idefics_model", checkpoint="HuggingFaceM4/idefics2-8b")
 idefics_client = RoboMLHTTPClient(idefics)
 
-mllm = MLLM(
+mllm = VLM(
     inputs=[text_query, image0, detections_topic],
     outputs=[text_answer],
     model_client=idefics_client,

--- a/docs/recipes/foundation/semantic-map.md
+++ b/docs/recipes/foundation/semantic-map.md
@@ -1,18 +1,28 @@
-# Semantic Map
+# Spatio-Temporal Memory
 
-Autonomous Mobile Robots (AMRs) keep a representation of their environment in the form of occupancy maps. One can layer semantic information on top of these occupancy maps and with the use of multimodal LLMs one can even add answers to arbitrary questions about the environment to this map. In EMOS such maps can be created using vector databases which are specifically designed to store natural language data and retrieve it based on natural language queries. Thus an embodied agent can keep a text based _spatio-temporal memory_, from which it can do retrieval to answer questions or do spatial planning.
+Autonomous Mobile Robots (AMRs) keep a representation of their environment in the form of occupancy maps. Such maps are fine for navigation but are *amnesic*: a robot doesn't *know* the objects, the rooms, the situations, or its own history. The [Memory](../../intelligence/memory.md) component gives an EMOS agent a structured place to store everything it perceives, indexed by **meaning**, **location**, and **time** — and to consolidate that stream of observations into long-term memory the way humans do.
 
-Here we will show an example of generating such a map using object detection information and questions answered by an MLLM. This map can of course be made arbitrarily complex and robust by adding checks on the data being stored, however in our example we will keep things simple. Lets start by importing relevant [components](../../intelligence/ai-components.md).
+In this recipe we wire perception into Memory: an object detector publishing `Detections`, a VLM publishing periodic introspective answers, both feeding `Memory` as separate layers. **Memory** runs on [eMEM](https://github.com/automatika-robotics/emem), a hybrid graph-based spatio-temporal memory built on neuroscience principles: tiered consolidation, episodic structure, entity persistence, and interoception as a first-class memory dimension.
 
-```python
-from agents.components import MapEncoding, Vision, MLLM
+```{seealso}
+For the conceptual background on Memory and the neuroscience principles behind it, see the [Memory page](../../intelligence/memory.md). Once you've built a memory and want to *reason over it* in plain English, the [Memory and Cortex](../planning-and-manipulation/cortex-memory.md) recipe shows how Cortex auto-discovers Memory's tools and uses them in its orchestration.
 ```
 
-Next, we will use a vision component to provide us with object detections, as we did in the [Prompt Engineering](prompt-engineering.md) recipe.
+```{admonition} Prerequisites
+:class: important
+
+The `Memory` component requires the [eMEM](https://github.com/automatika-robotics/emem) Python package. Install it into the same environment as the EMOS launcher before running this recipe:
+
+`pip install emem`
+```
+
+---
 
 ## Setting up a Vision Component
 
 ```python
+from agents.components import Vision
+from agents.config import VisionConfig
 from agents.ros import Topic
 
 # Define the image input topic
@@ -21,20 +31,21 @@ image0 = Topic(name="image_raw", msg_type="Image")
 detections_topic = Topic(name="detections", msg_type="Detections")
 ```
 
-Additionally the component requires a model client with an object detection model. We will use the RESP client for RoboML and use the VisionModel, a convenient model class made available in EMOS for initializing all vision models available in the opensource [mmdetection](https://github.com/open-mmlab/mmdetection) library. We will specify the model we want to use by specifying the checkpoint attribute.
+Additionally the component requires a model client with an object detection model. We will use the RESP client for [RoboML](https://github.com/automatika-robotics/roboml) and the `VisionModel` wrapper, which initialises any [HuggingFace Transformers object detection model](https://huggingface.co/models?pipeline_tag=object-detection) (RT-DETR, DETR, Grounding DINO, YOLOS, ...) by checkpoint name.
 
 ```{note}
-Learn about setting up RoboML with vision [here](https://www.github.com/automatika-robotics/roboml).
+Learn about setting up RoboML with vision [here](https://github.com/automatika-robotics/roboml/blob/main/README.md#vision-model-support).
 ```
 
 ```python
 from agents.models import VisionModel
-from agents.clients.roboml import RoboMLRESPClient
-from agents.config import VisionConfig
+from agents.clients import RoboMLRESPClient
 
 # Add an object detection model
-object_detection = VisionModel(name="object_detection",
-                               checkpoint="dino-4scale_r50_8xb2-12e_coco")
+object_detection = VisionModel(
+    name="object_detection",
+    checkpoint="PekingU/rtdetr_r50vd_coco_o365",
+)
 roboml_detection = RoboMLRESPClient(object_detection)
 
 # Initialize the Vision component
@@ -49,13 +60,16 @@ vision = Vision(
 )
 ```
 
-The vision component will provide us with semantic information to add to our map. However, object names are only the most basic semantic element of the scene. One can view such basic elements in aggregate to create more abstract semantic associations. This is where multimodal LLMs come in.
+The vision component will provide us with semantic information to add to memory. However, object names are only the most basic semantic element of the scene. One can view such basic elements in aggregate to create more abstract semantic associations. This is where multimodal LLMs come in.
 
-## Setting up an MLLM Component
+---
 
-With large scale multimodal LLMs we can ask higher level introspective questions about the sensor information the robot is receiving and record this information on our spatio-temporal map. As an example we will setup an MLLM component that periodically asks itself the same question, about the nature of the space the robot is present in. In order to achieve this we will use two concepts. First is that of a **FixedInput**, a simulated [Topic](../../concepts/topics.md) that has a fixed value whenever it is read by a listener. And the second is that of a _timed_ component. In EMOS, components can get triggered by either an input received on a Topic or automatically after a certain period of time. This latter trigger specifies a timed component. Lets see what all of this looks like in code.
+## Setting up a VLM Component
+
+With multimodal LLMs we can ask higher-level introspective questions about what the robot is currently seeing and store the answers in memory alongside the raw detections. We'll set up a VLM component that periodically asks itself the same question — what kind of room am I in? — using two EMOS concepts: a `FixedInput` (a simulated [Topic](../../concepts/topics.md) whose value is a constant string) and a *timed* component (one whose `trigger` is a frequency rather than an input topic).
 
 ```python
+from agents.components import VLM
 from agents.clients import OllamaClient
 from agents.models import OllamaModel
 from agents.ros import FixedInput
@@ -66,27 +80,30 @@ qwen_client = OllamaClient(qwen_vl)
 
 # Define a fixed input for the component
 introspection_query = FixedInput(
-    name="introspection_query", msg_type="String",
-    fixed="What kind of a room is this? Is it an office, a bedroom or a kitchen? Give a one word answer, out of the given choices")
+    name="introspection_query",
+    msg_type="String",
+    fixed=(
+        "What kind of a room is this? Is it an office, a bedroom or a kitchen? "
+        "Give a one word answer, out of the given choices"
+    ),
+)
 # Define output of the component
 introspection_answer = Topic(name="introspection_answer", msg_type="String")
 
 # Start a timed (periodic) component using the mllm model defined earlier
-# This component answers the same question after every 15 seconds
-introspector = MLLM(
-    inputs=[introspection_query, image0],  # we use the image0 topic defined earlier
+# This component answers the same question every 15 seconds
+introspector = VLM(
+    inputs=[introspection_query, image0],   # we use image0 from earlier
     outputs=[introspection_answer],
     model_client=qwen_client,
-    trigger=15.0,  # we provide the time interval as a float value to the trigger parameter
+    trigger=15.0,                           # frequency in seconds
     component_name="introspector",
 )
 ```
 
-LLM/MLLM model outputs can be unpredictable. Before publishing the answer of our question to the output topic, we want to ensure that the model has indeed provided a one word answer, and this answer is one of the expected choices. EMOS allows us to add arbitrary pre-processor functions to data that is going to be published (conversely, we can also add post-processing functions to data that has been received in a listener's callback, but we will see that in another recipe). We will add a simple pre-processing function to our output topic as follows:
+LLM/VLM model outputs can be unpredictable. Before publishing the answer of our question to the output topic, we want to ensure that the model has indeed provided a one word answer, and that this answer is one of the expected choices. EMOS allows arbitrary pre-processor functions on data being published; we'll add a tiny validator that drops anything outside the expected vocabulary:
 
 ```python
-# Define an arbitrary function to validate the output of the introspective component
-# before publication.
 from typing import Optional
 
 def introspection_validation(output: str) -> Optional[str]:
@@ -97,140 +114,148 @@ def introspection_validation(output: str) -> Optional[str]:
 introspector.add_publisher_preprocessor(introspection_answer, introspection_validation)
 ```
 
-This should ensure that our component only publishes the model output to this topic if the validation function returns an output. All that is left to do now is to setup our MapEncoding component.
+Now `introspection_answer` only carries clean one-word labels.
 
-## Creating a Semantic Map as a Vector DB
+---
 
-The final step is to store the output of our models in a spatio-temporal map. EMOS provides a MapEncoding component that takes input data being published by other components and appropriately stores them in a vector DB. The input to a MapEncoding component is in the form of map layers. A _MapLayer_ is a thin abstraction over _Topic_, with certain additional parameters. We will create our map layers as follows:
+## Building Memory
+
+The final step is to wire those two streams into a `Memory` component. Memory's input surface is a list of `MemLayer`s — each layer subscribes to a topic, and observations from that layer are tagged with a layer name in the underlying graph so you can later query *only* perception, *only* internal state, etc.
 
 ```python
-from agents.ros import MapLayer
+from agents.ros import MemLayer
 
 # Object detection output from vision component
-layer1 = MapLayer(subscribes_to=detections_topic, temporal_change=True)
+layer1 = MemLayer(subscribes_to=detections_topic)
 # Introspection output from mllm component
-layer2 = MapLayer(subscribes_to=introspection_answer, resolution_multiple=3)
+layer2 = MemLayer(subscribes_to=introspection_answer)
 ```
 
-_temporal_change_ parameter specifies that for the same spatial position the output coming in from the component needs to be stored along with timestamps, as the output can change over time. By default this option is set to **False**. _resolution_multiple_ specifies that we can coarse grain spatial coordinates by combining map grid cells.
+```{tip}
+Memory also models **interoception** — internal body state — as a first-class memory dimension. Adding a layer with `is_internal_state=True` (e.g. `MemLayer(subscribes_to=battery_topic, is_internal_state=True)`) routes those observations through `add_body_state` instead of `add`. They're queryable through the dedicated `body_status` tool and surface naturally alongside perception observations in `get_current_context`. We'll exercise this in the [Memory and Cortex](../planning-and-manipulation/cortex-memory.md) recipe.
+```
 
-Next we need to provide our component with localization information via an odometry topic and a map data topic (of type OccupancyGrid). The latter is necessary to know the actual resolution of the robots map.
+Memory needs the robot's pose (so every observation is tagged with where it was made) and two model clients — one for consolidation summarisation, one for embedding generation:
 
 ```python
-# Initialize mandatory topics defining the robots localization in space
+from agents.components import Memory
+from agents.config import MemoryConfig
+
+# Localization input — Memory uses these coordinates directly, no occupancy grid required
 position = Topic(name="odom", msg_type="Odometry")
-map_topic = Topic(name="map", msg_type="OccupancyGrid")
-```
 
-```{caution}
-Be sure to replace the name parameter in topics with the actual topic names being published on your robot.
-```
+# Embedding client for vector indexing of every observation
+embedding_model = OllamaModel(
+    name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest"
+)
+embedding_client = OllamaClient(embedding_model)
 
-Finally we initialize the MapEncoding component by providing it a database client. For the database client we will use HTTP DB client from RoboML. Much like model clients, the database client is initialized with a vector DB specification. For our example we will use Chroma DB, an open source multimodal vector DB.
-
-```{seealso}
-Checkout Chroma DB [here](https://trychroma.com).
-```
-
-```python
-from agents.vectordbs import ChromaDB
-from agents.clients import ChromaClient
-from agents.config import MapConfig
-
-# Initialize a vector DB that will store our semantic map
-chroma = ChromaDB()
-chroma_client = ChromaClient(db=chroma)
-
-# Create the map component
-map_conf = MapConfig(map_name="map")  # We give our map a name
-map = MapEncoding(
+memory = Memory(
     layers=[layer1, layer2],
     position=position,
-    map_topic=map_topic,
-    config=map_conf,
-    db_client=chroma_client,
-    trigger=15.0,  # map layer data is stored every 15 seconds
-    component_name="map_encoding",
+    model_client=qwen_client,        # used to summarise episodes into gists
+    embedding_client=embedding_client,
+    config=MemoryConfig(db_path="/tmp/robot_memory.db"),
+    trigger=15.0,                    # flush layer data into memory every 15s
+    component_name="memory",
 )
 ```
 
-## Launching the Components
+That single `Memory` component maintains:
 
-And as always we will launch our components as we did in the previous recipes.
+- A **typed graph** with four node types (Observation, Episode, Gist, Entity) and six edge types -- so the agent's memory is a structured object, not a flat blob of vectors.
+- **Tiered storage**, working &rarr; short-term &rarr; long-term &rarr; archived. Observations move through the tiers automatically as time passes; raw text is dropped after archival but the consolidated gist remains searchable.
+- **Three complementary indexes** sharing the graph: HNSW for semantic search, R-tree for spatial queries, SQLite indexes for temporal queries -- queryable independently or simultaneously.
+- **Automatic entity merging**: a new detection of "red chair" near a known "red chair" entity is recognised as the same entity rather than a new one, with cosine similarity *and* spatial proximity controlling the merge.
+
+You don't see any of this in the recipe — you wire layers in, and the structure emerges. See the [Memory page](../../intelligence/memory.md) for the architecture in detail.
+
+---
+
+## Wrapping Tasks in Episodes
+
+The VLM-introspector + detector pair is a good demonstration of layered memory ingestion, but in a real recipe you'd usually want to **bracket** the activity in an *episode*. Episodes are how Memory groups observations into task spans for consolidation: when an episode ends, eMEM clusters the observations made during it, asks the LLM to summarise each cluster into a *gist*, and archives the raw text -- the gist remains fully searchable in long-term memory.
+
+`Memory` exposes `start_episode` and `end_episode` as component actions — the simplest way to call them from a recipe is via [Events & Actions](../../concepts/events-and-actions.md). For example, you might trigger `start_episode` whenever the robot enters a new region and `end_episode` when it leaves. We'll show this pattern fully in [Memory and Cortex](../planning-and-manipulation/cortex-memory.md) where Cortex wraps every action task in an episode automatically.
+
+For now, every observation we feed in lives in working memory, gets flushed to short-term memory on the trigger schedule, and migrates to long-term as time accumulates.
+
+---
+
+## Launching the Components
 
 ```python
 from agents.ros import Launcher
 
-# Launch the components
 launcher = Launcher()
 launcher.add_pkg(
-    components=[vision, introspector, map]
-    )
+    components=[vision, introspector, memory],
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
+)
 launcher.bringup()
 ```
 
-And that is it. We have created our spatio-temporal semantic map using the outputs of two model components. The complete code for this recipe is below:
+That's it. The robot is now accumulating a structured spatio-temporal memory of everything Vision detects and everything the VLM introspects, indexed by where it happened and when.
+
+---
+
+## Full Recipe Code
 
 ```{code-block} python
-:caption: Semantic Mapping with MapEncoding
+:caption: Spatio-Temporal Memory with Vision and an Introspecting VLM
 :linenos:
 from typing import Optional
-from agents.components import MapEncoding, Vision, MLLM
-from agents.models import VisionModel, OllamaModel
-from agents.clients import RoboMLRESPClient, ChromaClient, OllamaClient
-from agents.ros import Topic, MapLayer, Launcher, FixedInput
-from agents.vectordbs import ChromaDB
-from agents.config import MapConfig, VisionConfig
 
-# Define the image input topic
+from agents.components import Memory, VLM, Vision
+from agents.config import MemoryConfig, VisionConfig
+from agents.models import OllamaModel, VisionModel
+from agents.clients import OllamaClient, RoboMLRESPClient
+from agents.ros import FixedInput, Launcher, MemLayer, Topic
+
+
+# --- Vision: object detection ---
 image0 = Topic(name="image_raw", msg_type="Image")
-# Create a detection topic
 detections_topic = Topic(name="detections", msg_type="Detections")
 
-# Add an object detection model
 object_detection = VisionModel(
-    name="object_detection", checkpoint="dino-4scale_r50_8xb2-12e_coco"
+    name="object_detection", checkpoint="PekingU/rtdetr_r50vd_coco_o365"
 )
 roboml_detection = RoboMLRESPClient(object_detection)
 
-# Initialize the Vision component
-detection_config = VisionConfig(threshold=0.5)
 vision = Vision(
     inputs=[image0],
     outputs=[detections_topic],
     trigger=image0,
-    config=detection_config,
+    config=VisionConfig(threshold=0.5),
     model_client=roboml_detection,
     component_name="detection_component",
 )
 
 
-# Define a model client (working with Ollama in this case)
+# --- VLM: periodic room-type introspection ---
 qwen_vl = OllamaModel(name="qwen_vl", checkpoint="qwen2.5vl:latest")
 qwen_client = OllamaClient(qwen_vl)
 
-# Define a fixed input for the component
 introspection_query = FixedInput(
     name="introspection_query",
     msg_type="String",
-    fixed="What kind of a room is this? Is it an office, a bedroom or a kitchen? Give a one word answer, out of the given choices",
+    fixed=(
+        "What kind of a room is this? Is it an office, a bedroom or a kitchen? "
+        "Give a one word answer, out of the given choices"
+    ),
 )
-# Define output of the component
 introspection_answer = Topic(name="introspection_answer", msg_type="String")
 
-# Start a timed (periodic) component using the mllm model defined earlier
-# This component answers the same question after every 15 seconds
-introspector = MLLM(
-    inputs=[introspection_query, image0],  # we use the image0 topic defined earlier
+introspector = VLM(
+    inputs=[introspection_query, image0],
     outputs=[introspection_answer],
     model_client=qwen_client,
-    trigger=15.0,  # we provide the time interval as a float value to the trigger parameter
+    trigger=15.0,
     component_name="introspector",
 )
 
 
-# Define an arbitrary function to validate the output of the introspective component
-# before publication.
 def introspection_validation(output: str) -> Optional[str]:
     for option in ["office", "bedroom", "kitchen"]:
         if option in output.lower():
@@ -239,35 +264,43 @@ def introspection_validation(output: str) -> Optional[str]:
 
 introspector.add_publisher_preprocessor(introspection_answer, introspection_validation)
 
-# Object detection output from vision component
-layer1 = MapLayer(subscribes_to=detections_topic, temporal_change=True)
-# Introspection output from mllm component
-layer2 = MapLayer(subscribes_to=introspection_answer, resolution_multiple=3)
 
-# Initialize mandatory topics defining the robots localization in space
+# --- Memory: graph-backed spatio-temporal store ---
+embedding_model = OllamaModel(
+    name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest"
+)
+embedding_client = OllamaClient(embedding_model)
+
 position = Topic(name="odom", msg_type="Odometry")
-map_topic = Topic(name="map", msg_type="OccupancyGrid")
 
-# Initialize a vector DB that will store our semantic map
-chroma = ChromaDB()
-chroma_client = ChromaClient(db=chroma)
+layer1 = MemLayer(subscribes_to=detections_topic, temporal_change=True)
+layer2 = MemLayer(subscribes_to=introspection_answer, resolution_multiple=3)
 
-# Create the map component
-map_conf = MapConfig(map_name="map")  # We give our map a name
-map = MapEncoding(
+memory = Memory(
     layers=[layer1, layer2],
     position=position,
-    map_topic=map_topic,
-    config=map_conf,
-    db_client=chroma_client,
+    model_client=qwen_client,
+    embedding_client=embedding_client,
+    config=MemoryConfig(db_path="/tmp/robot_memory.db"),
     trigger=15.0,
-    component_name="map_encoding",
+    component_name="memory",
 )
 
-# Launch the components
+
+# --- Launch ---
 launcher = Launcher()
 launcher.add_pkg(
-    components=[vision, introspector, map]
-    )
+    components=[vision, introspector, memory],
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
+)
 launcher.bringup()
 ```
+
+---
+
+## Where next
+
+- {doc}`Memory and Cortex <../planning-and-manipulation/cortex-memory>` — once you've built a memory, *reason* over it. Cortex auto-discovers all of Memory's retrieval tools and answers questions in plain English: *"where did you last see the cat?"*, *"summarise the last episode"*, *"is the kitchen messy right now?"*.
+- {doc}`Cortex: The Agentic Harness <../planning-and-manipulation/cortex-agent>` — the Cortex introduction, if you haven't met it yet.
+- {doc}`Memory concept page <../../intelligence/memory>` — the full architectural reference for eMEM: nodes, edges, tiers, consolidation, the ten retrieval tools.

--- a/docs/recipes/foundation/semantic-map.md
+++ b/docs/recipes/foundation/semantic-map.md
@@ -273,8 +273,8 @@ embedding_client = OllamaClient(embedding_model)
 
 position = Topic(name="odom", msg_type="Odometry")
 
-layer1 = MemLayer(subscribes_to=detections_topic, temporal_change=True)
-layer2 = MemLayer(subscribes_to=introspection_answer, resolution_multiple=3)
+layer1 = MemLayer(subscribes_to=detections_topic)
+layer2 = MemLayer(subscribes_to=introspection_answer)
 
 memory = Memory(
     layers=[layer1, layer2],

--- a/docs/recipes/foundation/tool-calling.md
+++ b/docs/recipes/foundation/tool-calling.md
@@ -1,161 +1,317 @@
 # Tool Calling
 
-In the previous [recipe](goto-navigation.md) we created a Go-to-X component using basic text manipulation on LLM output. However, for models that have been specifically trained for tool calling, one can get better results for structured outputs by invoking tool calling. At the same time tool calling can be useful to generate responses which require intermediate use of tools by the LLM before providing a final answer. In this recipe we will utilize tool calling for the former utility of getting a better structured output from the LLM, by reimplementing the Go-to-X component.
+In the [previous recipe](goto-navigation.md) we registered one of Memory's built-in tools (`locate`) on an LLM and let the LLM decide when to call it. That's the most direct path when the tool you want is already a `@component_action` on a managed component. **In this recipe we generalise the pattern**: we write our own Python function and register it as a tool on the LLM. The function can do anything Python can do -- read a sensor, hit a web service, toggle a piece of hardware, run a calculation -- and the LLM picks it up as a callable tool with the schema we declare.
 
-## Register a tool (function) to be called by the LLM
+The key idea: when the LLM is configured with one or more registered tools, it produces *structured tool calls* instead of raw text. A tool call has a name and JSON-serialisable arguments that match the tool's declared schema. The framework dispatches the call into our Python function, and we choose what happens to the return value -- either:
 
-To utilize tool calling we will change our strategy of doing pre-processing to LLM text output, and instead ask the LLM to provide structured input to a function (tool). The output of this function will then be sent for publishing to the output topic. Lets see what this will look like in the following code snippets.
+- `send_tool_response_to_model=True` — the function's return is fed back to the LLM as a tool result, and the LLM produces a follow-up generation that uses it. The right mode when you want the LLM to *react* to the tool's answer.
+- `send_tool_response_to_model=False` — the function's return value *is* the LLM component's output, and gets published on the output topic directly. The right mode when you just want the LLM to extract structured arguments and you handle the rest. This was what we used in the [GoTo Navigation](goto-navigation.md) recipe.
 
-First we will modify the component level prompt for our LLM.
+Tool calling works with any client that supports it -- the `OllamaClient` and the `GenericHTTPClient` both do, as long as the underlying model is tool-trained.
 
-```python
-# set a component prompt
-goto.set_component_prompt(
-    template="""What are the position coordinates in the given metadata?"""
-)
-```
+---
 
-Next we will replace our pre-processing function, with a much simpler function that takes in a list and provides a numpy array. The LLM will be expected to call this function with the appropriate output. This strategy generally works better than getting text input from LLM and trying to parse it with an arbitrary function. To register the function as a tool, we will also need to create its description in a format that is explanatory for the LLM. This format has been specified by the _Ollama_ client.
+## What we're building
 
-```{caution}
-Tool calling is currently available only when components utilize the OllamaClient.
-```
+A tiny voice-of-the-world agent: an LLM component that can answer questions about the **current weather anywhere on Earth** by calling a custom function that hits the public [Open-Meteo](https://open-meteo.com) API. Weather is the canonical case for tool calling -- the LLM categorically can't know it from training data, so the tool earns its place by giving the model live information it would otherwise have to invent.
 
-```{seealso}
-To see a list of models that work for tool calling using the OllamaClient, check [here](https://ollama.com/search?c=tools)
-```
+| Component | Role |
+|---|---|
+| **LLM** | Receives a free-form question, decides whether to call our `get_weather` tool, and composes a natural-language reply. |
+| **`get_weather` tool** | A regular Python function that geocodes a city name, queries Open-Meteo, and returns the current conditions. |
 
-```python
-# pre-process the output before publishing to a topic of msg_type PoseStamped
-def get_coordinates(position: list[float]) -> np.ndarray:
-    """Get position coordinates"""
-    return np.array(position, dtype=float)
+This shows the *full* tool-calling loop: tool result back to LLM → LLM phrases an answer in natural language. Anywhere we'd like the LLM to *use* live data instead of hallucinating it -- a sensor reading, a database row, a web fetch, a sub-process -- follows the same shape.
 
+---
 
-function_description = {
-    "type": "function",
-    "function": {
-        "name": "get_coordinates",
-        "description": "Get position coordinates",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "position": {
-                    "type": "list[float]",
-                    "description": "The position coordinates in x, y and z",
-                }
-            },
-        },
-        "required": ["position"],
-    },
-}
+## Step 1: The LLM
 
-# add the pre-processing function to the goal_point output topic
-goto.register_tool(
-    tool=get_coordinates,
-    tool_description=function_description,
-    send_tool_response_to_model=False,
-)
-```
-
-In the code above, the flag _send_tool_response_to_model_ has been set to False. This means that the function output will be sent directly for publication, since our usage of the tool in this recipe is limited to forcing the model to provide a structured output. If this flag was set to True, the output of the tool (function) will be sent back to the model to produce the final output, which will then be published. This latter usage is employed when a tool like a calculator, browser or code interpreter can be provided to the model for generating better answers.
-
-## Launching the Components
-
-And as before, we will launch our Go-to-X component.
+A plain `LLM` component using a tool-capable Ollama model.
 
 ```python
-from agents.ros import Launcher
-
-# Launch the component
-launcher = Launcher()
-launcher.add_pkg(components=[goto])
-launcher.bringup()
-```
-
-The complete code for this recipe is given below:
-
-```{code-block} python
-:caption: Go-to-X Component with Tool Calling
-:linenos:
-import numpy as np
+from agents.clients import OllamaClient
 from agents.components import LLM
-from agents.models import OllamaModel
-from agents.vectordbs import ChromaDB
 from agents.config import LLMConfig
-from agents.clients import ChromaClient, OllamaClient
+from agents.models import OllamaModel
 from agents.ros import Launcher, Topic
 
-# Start a Llama3.2 based llm component using ollama client
-llama = OllamaModel(name="llama", checkpoint="llama3.2:3b")
-llama_client = OllamaClient(llama)
+qwen = OllamaModel(name="qwen", checkpoint="qwen3.5:latest")
+qwen_client = OllamaClient(qwen)
 
-# Initialize a vector DB that will store our routes
-chroma = ChromaDB()
-chroma_client = ChromaClient(db=chroma)
+question = Topic(name="question", msg_type="String")
+answer = Topic(name="answer", msg_type="String")
 
-# Define LLM input and output topics including goal_point topic of type PoseStamped
-goto_in = Topic(name="goto_in", msg_type="String")
-goal_point = Topic(name="goal_point", msg_type="PoseStamped")
-
-config = LLMConfig(
-    enable_rag=True,
-    collection_name="map",
-    distance_func="l2",
-    n_results=1,
-    add_metadata=True,
+assistant = LLM(
+    inputs=[question],
+    outputs=[answer],
+    model_client=qwen_client,
+    trigger=question,
+    config=LLMConfig(),
+    component_name="assistant",
 )
 
-# initialize the component
-goto = LLM(
-    inputs=[goto_in],
-    outputs=[goal_point],
-    model_client=llama_client,
-    db_client=chroma_client,  # check the previous example where we setup this database client
-    trigger=goto_in,
-    config=config,
-    component_name="go_to_x",
+assistant.set_component_prompt(
+    template=(
+        "You are a friendly assistant. If the user asks about the current "
+        "weather, temperature, or wind in a location, call the "
+        "``get_weather`` tool with the city name and answer using the data "
+        "it returns. The user said: {{question}}"
+    )
 )
+```
 
-# set a component prompt
-goto.set_component_prompt(
-    template="""What are the position coordinates in the given metadata?"""
-)
+The prompt nudges the model toward the tool when the question is weather-related. For unrelated questions the LLM will just answer directly without calling anything.
+
+---
+
+## Step 2: Define the tool
+
+A regular Python function that takes a city name, geocodes it, and queries the Open-Meteo current-conditions endpoint. No API key required.
+
+```python
+from typing import Dict, Union
+
+import httpx
 
 
-# pre-process the output before publishing to a topic of msg_type PoseStamped
-def get_coordinates(position: list[float]) -> np.ndarray:
-    """Get position coordinates"""
-    return np.array(position, dtype=float)
+def get_weather(city: str) -> Dict[str, Union[str, float]]:
+    """Look up the current weather for *city* via the Open-Meteo public API.
 
+    Returns a dict with the city's resolved name, temperature, and wind
+    speed -- or ``{"error": "..."}`` if the city couldn't be resolved.
+    """
+    # Geocoding: city name -> (lat, lon)
+    geo = httpx.get(
+        "https://geocoding-api.open-meteo.com/v1/search",
+        params={"name": city, "count": 1},
+        timeout=10.0,
+    ).json()
+    if not geo.get("results"):
+        return {"error": f"could not find location '{city}'"}
 
-function_description = {
+    place = geo["results"][0]
+    lat, lon = place["latitude"], place["longitude"]
+
+    # Current weather at those coordinates
+    weather = httpx.get(
+        "https://api.open-meteo.com/v1/forecast",
+        params={
+            "latitude": lat,
+            "longitude": lon,
+            "current": "temperature_2m,wind_speed_10m",
+        },
+        timeout=10.0,
+    ).json()["current"]
+
+    return {
+        "city": place.get("name", city),
+        "country": place.get("country", ""),
+        "temperature_c": weather["temperature_2m"],
+        "wind_speed_kmh": weather["wind_speed_10m"],
+    }
+```
+
+`httpx` is already a dependency of EMOS, so no extra install. The function:
+
+- takes one string argument (`city`),
+- does its own work (two HTTP calls -- geocoding, then weather),
+- returns a small dict the LLM can phrase prose around.
+
+---
+
+## Step 3: Declare the tool's schema
+
+The LLM needs an OpenAI-format description so it knows the tool's name, what it does, and what arguments to provide.
+
+```python
+get_weather_description = {
     "type": "function",
     "function": {
-        "name": "get_coordinates",
-        "description": "Get position coordinates",
+        "name": "get_weather",
+        "description": (
+            "Look up the current weather (temperature in Celsius and wind "
+            "speed in km/h) for a given city. Call this whenever the user "
+            "asks about live weather conditions anywhere in the world."
+        ),
         "parameters": {
             "type": "object",
             "properties": {
-                "position": {
-                    "type": "list[float]",
-                    "description": "The position coordinates in x, y and z",
-                }
+                "city": {
+                    "type": "string",
+                    "description": (
+                        "City name, optionally with country (e.g. 'Berlin', "
+                        "'Tokyo', 'Paris, France')."
+                    ),
+                },
             },
+            "required": ["city"],
         },
-        "required": ["position"],
+    },
+}
+```
+
+Spend the description budget on telling the model **when** to call the tool and what the arguments mean. The LLM doesn't see the function body; it only sees the description.
+
+---
+
+## Step 4: Register the tool
+
+```python
+assistant.register_tool(
+    tool=get_weather,
+    tool_description=get_weather_description,
+    send_tool_response_to_model=True,
+)
+```
+
+`send_tool_response_to_model=True` is what makes this recipe a conversational loop:
+
+1. User asks *"what's the weather in Berlin right now?"*.
+2. LLM emits a structured `get_weather(city="Berlin")` tool call.
+3. Framework dispatches the call, the function geocodes Berlin and hits Open-Meteo.
+4. The result -- `{"city": "Berlin", "country": "Germany", "temperature_c": 18.3, "wind_speed_kmh": 11.5}` -- is fed back into the LLM as a tool message.
+5. The LLM produces the final user-facing reply: *"It's currently 18°C in Berlin with a light breeze around 12 km/h."*
+6. That reply gets published on `answer`.
+
+If the user asks something off-topic (*"what's the capital of Peru?"*), the LLM never calls the tool and answers from its own knowledge.
+
+---
+
+## Step 5: Launch
+
+```python
+launcher = Launcher()
+launcher.add_pkg(components=[assistant])
+launcher.bringup()
+```
+
+---
+
+## Full recipe code
+
+```{code-block} python
+:caption: Tool calling on an LLM with a custom weather-lookup tool
+:linenos:
+from typing import Dict, Union
+
+import httpx
+
+from agents.clients import OllamaClient
+from agents.components import LLM
+from agents.config import LLMConfig
+from agents.models import OllamaModel
+from agents.ros import Launcher, Topic
+
+
+# -- LLM --
+qwen = OllamaModel(name="qwen", checkpoint="qwen3.5:latest")
+qwen_client = OllamaClient(qwen)
+
+question = Topic(name="question", msg_type="String")
+answer = Topic(name="answer", msg_type="String")
+
+assistant = LLM(
+    inputs=[question],
+    outputs=[answer],
+    model_client=qwen_client,
+    trigger=question,
+    config=LLMConfig(),
+    component_name="assistant",
+)
+
+assistant.set_component_prompt(
+    template=(
+        "You are a friendly assistant. If the user asks about the current "
+        "weather, temperature, or wind in a location, call the "
+        "``get_weather`` tool with the city name and answer using the data "
+        "it returns. The user said: {{question}}"
+    )
+)
+
+
+# -- Custom tool: live weather via Open-Meteo --
+def get_weather(city: str) -> Dict[str, Union[str, float]]:
+    """Look up the current weather for *city* via the Open-Meteo public API."""
+    geo = httpx.get(
+        "https://geocoding-api.open-meteo.com/v1/search",
+        params={"name": city, "count": 1},
+        timeout=10.0,
+    ).json()
+    if not geo.get("results"):
+        return {"error": f"could not find location '{city}'"}
+
+    place = geo["results"][0]
+    lat, lon = place["latitude"], place["longitude"]
+
+    weather = httpx.get(
+        "https://api.open-meteo.com/v1/forecast",
+        params={
+            "latitude": lat,
+            "longitude": lon,
+            "current": "temperature_2m,wind_speed_10m",
+        },
+        timeout=10.0,
+    ).json()["current"]
+
+    return {
+        "city": place.get("name", city),
+        "country": place.get("country", ""),
+        "temperature_c": weather["temperature_2m"],
+        "wind_speed_kmh": weather["wind_speed_10m"],
+    }
+
+
+get_weather_description = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": (
+            "Look up the current weather (temperature in Celsius and wind "
+            "speed in km/h) for a given city. Call this whenever the user "
+            "asks about live weather conditions anywhere in the world."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": (
+                        "City name, optionally with country (e.g. 'Berlin', "
+                        "'Tokyo', 'Paris, France')."
+                    ),
+                },
+            },
+            "required": ["city"],
+        },
     },
 }
 
-# add the pre-processing function to the goal_point output topic
-goto.register_tool(
-    tool=get_coordinates,
-    tool_description=function_description,
-    send_tool_response_to_model=False,
+assistant.register_tool(
+    tool=get_weather,
+    tool_description=get_weather_description,
+    send_tool_response_to_model=True,
 )
 
-# Launch the component
+
+# -- Launch --
 launcher = Launcher()
-launcher.add_pkg(components=[goto])
+launcher.add_pkg(components=[assistant])
 launcher.bringup()
 ```
+
+---
+
+## When to use which pattern
+
+| Need | Pattern |
+|---|---|
+| Use a tool that's already a `@component_action` on a managed component, with its existing schema. | `memory.register_tools_on(llm, tools=[...])` from [GoTo Navigation](goto-navigation.md). |
+| Custom Python function as the tool, with a schema you define. | `llm.register_tool(your_function, your_description, send_tool_response_to_model=...)` -- this recipe. |
+| Multiple capabilities orchestrated by an LLM that decides what to do. | A [Cortex](../../intelligence/cortex.md) component, which auto-discovers every `@component_action` on every managed component as a tool with no per-tool registration. |
+
+And within the custom-function pattern itself:
+
+| `send_tool_response_to_model` | When |
+|---|---|
+| `True` (this recipe) | The LLM should *react* to the tool's output -- compose a sentence, decide what to do next, ask a follow-up. Conversational and reasoning agents. |
+| `False` ([GoTo Navigation](goto-navigation.md)) | The tool's return value is what should be published. You're using the LLM to extract structured arguments, and the function does the real work. |

--- a/docs/recipes/navigation/vision-tracking-depth.md
+++ b/docs/recipes/navigation/vision-tracking-depth.md
@@ -83,20 +83,23 @@ my_robot = RobotConfig(
 
 ## Step 3: Controller with VisionRGBDFollower
 
-Now we set up the `Controller` component to use the `VisionRGBDFollower`. Compared to the RGB version, we need two additional inputs:
+Now we set up the `Controller` component to use the `VisionRGBDFollower`. In Kompass the controller selects between path-following and vision-following modes via its **algorithm**, and `VisionRGBDFollower` and `VisionRGBFollower` are sibling controllers that live behind `ControllersID.VISION_DEPTH` and `ControllersID.VISION_IMG` respectively.
+
+Compared to the [RGB version](vision-tracking-rgb.md), the RGBD path needs two additional inputs:
 
 - The **detections topic** from the vision component
 - The **depth camera info topic** for depth-to-3D projection
 
 ```python
 from kompass.components import Controller, ControllerConfig
+from kompass.control import ControllersID
 
 depth_cam_info_topic = Topic(name="/camera/aligned_depth_to_color/camera_info", msg_type="CameraInfo")
 
 config = ControllerConfig(ctrl_publish_type="Parallel")
 controller = Controller(component_name="controller", config=config)
+controller.algorithm = ControllersID.VISION_DEPTH
 controller.inputs(vision_detections=detections_topic, depth_camera_info=depth_cam_info_topic)
-controller.algorithm = "VisionRGBDFollower"
 ```
 
 ---
@@ -127,6 +130,7 @@ from agents.components import Vision
 from agents.config import VisionConfig
 from agents.ros import Topic
 from kompass.components import Controller, ControllerConfig, DriveManager, LocalMapper
+from kompass.control import ControllersID
 from kompass.robot import (
     AngularCtrlLimits,
     LinearCtrlLimits,
@@ -166,8 +170,8 @@ depth_cam_info_topic = Topic(name="/camera/aligned_depth_to_color/camera_info", 
 # Setup the controller
 config = ControllerConfig(ctrl_publish_type="Parallel")
 controller = Controller(component_name="controller", config=config)
+controller.algorithm = ControllersID.VISION_DEPTH
 controller.inputs(vision_detections=detections_topic, depth_camera_info=depth_cam_info_topic)
-controller.algorithm = "VisionRGBDFollower"
 controller.direct_sensor = False
 
 # Add additional helper components
@@ -176,11 +180,17 @@ mapper = LocalMapper(component_name="local_mapper")
 
 # Bring it up with the launcher
 launcher = Launcher()
-launcher.add_pkg(components=[vision], ros_log_level="warn",
-                 package_name="automatika_embodied_agents",
-                 executable_entry_point="executable",
-                 multiprocessing=True)
-launcher.kompass(components=[controller, mapper, driver])
+launcher.add_pkg(
+    components=[vision],
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
+    ros_log_level="warn",
+)
+launcher.add_pkg(
+    components=[controller, mapper, driver],
+    package_name="kompass",
+    multiprocessing=True,
+)
 # Set the robot config for all components
 launcher.robot = my_robot
 launcher.bringup()

--- a/docs/recipes/navigation/vision-tracking-rgb.md
+++ b/docs/recipes/navigation/vision-tracking-rgb.md
@@ -11,6 +11,7 @@ In this tutorial we will create a vision-based target following navigation syste
 Based on the type of the camera used on your robot, you need to install and launch its respective ROS 2 node provided by the manufacturer.
 
 To run and test this example on your development machine, you can use your webcam along with the `usb_cam` package:
+
 ```shell
 sudo apt install ros-<ros2-distro>-usb-cam
 ros2 run usb_cam usb_cam_node_exe
@@ -30,6 +31,7 @@ After installing both packages, you can start `roboml` to serve the model later 
 ```shell
 roboml-resp
 ```
+
 ```{tip}
 Save the IP of the machine running `roboml` as we will use it later in our model client.
 ```
@@ -50,12 +52,13 @@ Now let's configure the model we want to use for detections/tracking and the mod
 ```python
 object_detection = VisionModel(
     name="object_detection",
-    checkpoint="rtmdet_tiny_8xb32-300e_coco",
+    checkpoint="PekingU/rtdetr_r50vd_coco_o365",
 )
 roboml_detection = RoboMLRESPClient(object_detection, host='127.0.0.1', logging_level="warn")
   # 127.0.0.1 should be replaced by the IP of the machine running roboml.
 ```
-The model is configured with a name and a checkpoint (any checkpoint from the mmdetection framework can be used, see [available checkpoints](https://github.com/open-mmlab/mmdetection?tab=readme-ov-file#overview-of-benchmark-and-model-zoo)). In this example, we have chosen a model checkpoint trained on the MS COCO dataset which has over 80 [classes](https://github.com/amikelive/coco-labels/blob/master/coco-labels-2014_2017.txt) of commonly found objects.
+
+The model is configured with a name and a checkpoint. RoboML's `VisionModel` works with any [HuggingFace Transformers object detection model](https://huggingface.co/models?pipeline_tag=object-detection) (RT-DETR, DETR, Grounding DINO, YOLOS, etc.). In this example we use the RT-DETR checkpoint pretrained on COCO + Objects365, which covers over 80 [classes](https://github.com/amikelive/coco-labels/blob/master/coco-labels-2014_2017.txt) of commonly found objects.
 
 ---
 
@@ -95,6 +98,7 @@ vision = Vision(
     component_name="detection_component",
 )
 ```
+
 The component inputs/outputs are defined to get the images from the camera topic and provide both detections and trackings. The `trigger` of the component is set to the image input topic so the component works in an Event-Based runtype and provides a new detection/tracking on each new image.
 
 In the component configuration, the parameter `enable_visualization` is set to `True` to get a visualization of the output on an additional pop-up window for debugging purposes. The `threshold` parameter (confidence threshold for object detection) is set to `0.5`.
@@ -137,19 +141,19 @@ See more details about the robot configuration in the [Point Navigation](point-n
 
 To implement the target following system we will use the `Controller` component to generate the tracking commands and the `DriveManager` to handle the safe communication with the robot driver.
 
-We select the vision follower method parameters by importing the config class `VisionRGBFollowerConfig` (see default parameters in the [Algorithms](../../advanced/algorithms.md) reference), then configure both our components:
+The controller selects between path-following (e.g. `DWA`) and vision-following modes via its **algorithm**. We pick `ControllersID.VISION_IMG` for an RGB-only follower (the RGB and RGBD followers are sibling controllers with their own configs -- see [Vision Tracking with Depth](vision-tracking-depth.md) for the RGBD path).
 
 ```python
 from kompass.components import Controller, ControllerConfig, DriveManager
-from kompass.control import VisionRGBFollowerConfig
+from kompass.control import ControllersID, VisionRGBFollowerConfig
 
 # Set the controller component configuration
 config = ControllerConfig(loop_rate=10.0, ctrl_publish_type="Sequence", control_time_step=0.3)
 
-# Init the controller
-controller = Controller(
-    component_name="my_controller", config=config
-)
+# Init the controller and pick the RGB-only vision follower
+controller = Controller(component_name="my_controller", config=config)
+controller.algorithm = ControllersID.VISION_IMG
+
 # Set the vision tracking input to either the detections or trackings topic
 controller.inputs(vision_tracking=detections_topic)
 
@@ -162,6 +166,7 @@ controller.algorithms_config = vision_follower_config
 # Init the drive manager with the default parameters
 driver = DriveManager(component_name="my_driver")
 ```
+
 Here we selected a loop rate for the controller of `10Hz` and a control step for generating the commands of `0.3s`, and we selected to send the commands sequentially as they get computed. The vision follower is configured with a `control_horizon` equal to three future control time steps and a `target_search_pause` equal to 6 control time steps. We also chose to disable the search, meaning that the tracking action would end when the robot loses the target.
 
 ```{tip}
@@ -182,12 +187,16 @@ launcher = Launcher()
 # setup agents as a package in the launcher and add the vision component
 launcher.add_pkg(
     components=[vision],
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
     ros_log_level="warn",
 )
 
 # setup the navigation components in the launcher
-launcher.kompass(
+launcher.add_pkg(
     components=[controller, driver],
+    package_name="kompass",
+    multiprocessing=True,
 )
 # Set the robot config for all components
 launcher.robot = my_robot
@@ -219,7 +228,7 @@ from kompass.robot import (
     RobotType,
     RobotConfig,
 )
-from kompass.control import VisionRGBFollowerConfig
+from kompass.control import ControllersID, VisionRGBFollowerConfig
 from kompass.ros import Launcher
 
 # RGB camera input topic is set to the compressed image topic
@@ -231,7 +240,7 @@ trackings_topic = Topic(name="trackings", msg_type="Trackings")
 
 object_detection = VisionModel(
     name="object_detection",
-    checkpoint="rtmdet_tiny_8xb32-300e_coco",
+    checkpoint="PekingU/rtdetr_r50vd_coco_o365",
 )
 roboml_detection = RoboMLRESPClient(object_detection, host='127.0.0.1', logging_level="warn")
 
@@ -264,8 +273,9 @@ config = ControllerConfig(
     loop_rate=10.0, ctrl_publish_type="Sequence", control_time_step=0.3
 )
 
-# Init the controller
+# Init the controller and pick the RGB-only vision follower
 controller = Controller(component_name="my_controller", config=config)
+controller.algorithm = ControllersID.VISION_IMG
 controller.inputs(vision_tracking=detections_topic)
 
 # Set the vision follower configuration
@@ -280,10 +290,14 @@ driver = DriveManager(component_name="my_driver")
 launcher = Launcher()
 launcher.add_pkg(
     components=[vision],
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
     ros_log_level="warn",
 )
-launcher.kompass(
+launcher.add_pkg(
     components=[controller, driver],
+    package_name="kompass",
+    multiprocessing=True,
 )
 launcher.robot = my_robot
 launcher.bringup()

--- a/docs/recipes/overview.md
+++ b/docs/recipes/overview.md
@@ -18,82 +18,105 @@ The core promise of EMOS Recipes is hardware independence. A "Security Patrol" r
 
 The tutorials in this section follow a graduated structure, building from simple single-component examples to a full agentic system. They are organized into four subsections:
 
-- {material-regular}`psychology;1.2em;sd-text-primary` **[Cognition Recipes](foundation/index.md)** -- Build intelligent agents from the ground up using [EmbodiedAgents](https://github.com/automatika-robotics/embodied-agents): conversational agents, prompt engineering, semantic maps, navigation via RAG, tool calling, semantic routing, and a complete end-to-end agent.
+- {material-regular}`psychology;1.2em;sd-text-primary` **[Cognition Recipes](foundation/index.md)** -- Build intelligent agents from the ground up using [EmbodiedAgents](https://github.com/automatika-robotics/embodied-agents): conversational agents, prompt engineering, graph-backed spatio-temporal memory, memory-aware navigation, tool calling, semantic routing, and a complete end-to-end agent.
 
-- {material-regular}`precision_manufacturing;1.2em;sd-text-primary` **[Multimodal Planning & Manipulation](planning-and-manipulation/index.md)** -- Advanced AI capabilities: VLM-based planning and VLA-based end-to-end robotic manipulation, including event-driven closed-loop control.
+- {material-regular}`precision_manufacturing;1.2em;sd-text-primary` **[Multimodal Planning & Manipulation](planning-and-manipulation/index.md)** -- The [Cortex](../intelligence/cortex.md) agentic harness (drop one component into your recipe and it turns the rest into a self-directing agent), Cortex paired with Memory, Cortex driving the full stack on a mobile robot, plus VLM-based planning and VLA-based end-to-end manipulation.
 
 - {material-regular}`route;1.2em;sd-text-primary` **[Navigation](navigation/index.md)** -- Set up and use [Kompass](https://github.com/automatika-robotics/kompass), the EMOS navigation engine: simulation quick starts, point navigation, path recording and replay, automated motion testing, and vision-based target tracking with RGB and depth cameras.
 
-- {material-regular}`healing;1.2em;sd-text-primary` **[Adaptivity & Resilience](events-and-resilience/index.md)** -- Make your agents robust and adaptive using multiprocessing, runtime fallbacks, event-driven cognition, cross-component healing, composed logic gates, and context-aware dynamic actions.
+- {material-regular}`healing;1.2em;sd-text-primary` **[Adaptivity & Resilience](events-and-resilience/index.md)** -- Make your agents robust and adaptive using multiprocessing with process-level recovery, runtime fallbacks, event-driven cognition, the System Graph view for visualising the running graph, cross-component healing, composed logic gates, and context-aware dynamic actions.
 
 ## Recipe Examples
 
-Below are four real-world examples that illustrate what EMOS Recipes look like in practice. Each is a self-contained Python snippet that defines an agentic workflow.
+Below are five real-world examples that illustrate what EMOS Recipes look like in practice. Each is a tight Python snippet showing the *shape* of the recipe -- not the full file -- with a link to the full tutorial it lives in.
 
-### 1. The General Purpose Assistant
+### 1. The Warehouse Auditor
 
-*A robot that intelligently routes verbal commands to the correct capability.*
+*A mobile robot that walks the aisles overnight, checks the shelves, and writes the variance report.*
 
-This recipe uses a **Semantic Router** to analyze user intent. "Go to the kitchen" routes to Kompass for navigation, while "What tool is this?" routes to a VLM for visual question answering.
+You don't tell it which aisles in what order. You give it the mission -- *"audit aisle 4 and flag anything misshelved or out of stock"* -- and a [Cortex](../intelligence/cortex.md) component on top of Vision, a VLM, Memory, and the Kompass navigation stack inspects every component as a callable tool, plans the steps, dispatches navigation goals, calls the VLM at each shelf, and replans on failure. Zero orchestration glue from you.
 
 ```python
-# Define routing logic based on semantic meaning, not just keywords
-llm_route = Route(samples=["What is the torque for M6?", "Convert inches to mm"])
-mllm_route = Route(samples=["What tool is this?", "Is the safety light on?"])
-goto_route = Route(samples=["Go to the CNC machine", "Move to storage"])
-
-# The Semantic Router directs traffic based on intent
-router = SemanticRouter(
-    inputs=[query_topic],
-    routes=[llm_route, goto_route, mllm_route], # Routes to Chat, Nav, or Vision
-    default_route=llm_route,
-    config=router_config
+# That's the agent. It auto-discovers every other component in the
+# launcher and exposes their actions as skills and tools.
+cortex = Cortex(
+    output=cortex_output,
+    model_client=planner_client,
+    config=CortexConfig(max_planning_steps=5, max_execution_steps=15),
+    component_name="cortex",
 )
 ```
 
-### 2. The Resilient "Always-On" Agent
+See: [Cortex Driving the Full Stack](planning-and-manipulation/cortex-navigation.md).
 
-*Ensuring uptime by falling back to local compute when the internet fails.*
+### 2. The Home Care Companion
 
-This demonstrates **Runtime Robustness**. We bind an `on_algorithm_fail` [event](../concepts/events-and-actions.md) to the intelligence component. If the cloud API disconnects, the Recipe triggers a specific recovery action rather than crashing.
+*A household robot that learns the layout of the home it's deployed in -- and remembers it after a reboot.*
 
-```python
-# If the cloud API fails (runtime), instantly switch to the local backup model
-llm_component.on_algorithm_fail(
-    action=switch_to_backup,
-    max_retries=3
-)
-```
-
-### 3. The Self-Recovering Warehouse Robot
-
-*A robot that unjams itself without human intervention.*
-
-Instead of a "Red Light" error, the robot uses an [event/action pair](../concepts/events-and-actions.md) to trigger a specific maneuvering routine when the planner gets stuck.
+[Memory](../intelligence/memory.md) folds every detection, scene caption, and interoception reading into a graph indexed simultaneously by **meaning**, **location**, and **time**. Episodes consolidate into long-term gists; the same fridge gets recognised across different sessions; the whole memory state is in a SQLite file. Power-cycle the robot, point it at the same `db_path`, and the robot never forgets a thing.
 
 ```python
-events_actions = {
-    # If the emergency stop triggers, restart the planner and back away
-    event_emergency_stop: [
-        ComponentActions.restart(component=planner),
-        unblock_action,
+memory = Memory(
+    layers=[
+        MemLayer(subscribes_to=detections),
+        MemLayer(subscribes_to=scene_caption),
+        MemLayer(subscribes_to=battery, is_internal_state=True),
     ],
-    # If the controller algorithm fails, attempt unblocking maneuver
-    event_controller_fail: unblock_action,
+    position=position,
+    embedding_client=embedding_client,
+    config=MemoryConfig(db_path="/var/lib/robot/memory.db"),
+    component_name="memory",
+)
+```
+
+See: [Spatio-Temporal Memory](foundation/semantic-map.md), [Memory and Cortex](planning-and-manipulation/cortex-memory.md).
+
+### 3. The Last-Mile Delivery Worker
+
+*A delivery worker robot that pulls itself over to a charging pad before its battery dies on someone's lawn.*
+
+Halfway through a multi-stop route, it notices its charge is getting thin and it's still a long way from base. It diverts to the nearest pad, tops up, and continues the run from where it left off -- no operator in the loop, no aborted delivery.
+
+```python
+def needs_to_recharge() -> bool:
+    return battery_pct() < 15.0 and distance_to_depot_m() > 200.0
+
+events_actions = {
+    Event(needs_to_recharge, check_rate=1.0): return_to_nearest_pad,
 }
 ```
 
-### 4. The "Off-Grid" Field Mule
+See: [Internal-State Events](events-and-resilience/internal-state-events.md).
 
-*Follow-me functionality in unmapped environments.*
+### 4. The 24/7 Security Patrol
 
-Using the `VisionRGBDFollower`, the robot fuses depth data with visual detection to "lock on" to a human guide, ignoring the need for GPS or SLAM.
+*A patrol robot that stays on its rounds through model-server outages, segfaults, and OS hiccups -- without anyone in the loop.*
+
+Two layers of recovery applied to the whole graph in a few lines. The first reacts to unhealthy components in-process; the second relaunches a component if its process actually exits.
 
 ```python
-# Setup controller to use Depth + Vision Fusion
+for component in all_components:
+    component.on_fail(action=Action(component.restart), max_retries=2)
+
+launcher.on_process_fail(max_retries=3)   # OS-level safety net
+```
+
+See: [Multiprocessing & Fault Tolerance](events-and-resilience/multiprocessing.md), [Status & Fallbacks](../concepts/status-and-fallbacks.md).
+
+### 5. The "Off-Grid" Field Mule
+
+*A porter robot that follows a worker around a construction site, no GPS or SLAM required.*
+
+Depth fusion + visual detection lock on to a human guide and the controller follows them. The whole behaviour is one controller-config switch.
+
+```python
+from kompass.control import ControllersID
+
+controller.algorithm = ControllersID.VISION_DEPTH
 controller.inputs(
     vision_detections=detections_topic,
-    depth_camera_info=depth_cam_info_topic
+    depth_camera_info=depth_cam_info_topic,
 )
-controller.algorithm = "VisionRGBDFollower"
 ```
+
+See: [Vision Tracking with Depth](navigation/vision-tracking-depth.md).

--- a/docs/recipes/planning-and-manipulation/cortex-agent.md
+++ b/docs/recipes/planning-and-manipulation/cortex-agent.md
@@ -1,0 +1,235 @@
+# Cortex: The Agentic Harness
+
+**A single component, dropped on top of the rest of your recipe, that turns it into a self-directed agent.**
+
+Most EMOS recipes you've seen so far are *programmed*: events trigger components, components publish to topics, fallbacks recover from failure -- and you, the recipe author, hand-wired every link. The Cortex component is a different shape. Drop a Cortex into your recipe and it discovers every other component you added, registers every method they expose as a callable tool, and -- given a high-level goal like *"track the person on the left and tell me what they're holding"* -- decomposes it into an ordered plan, dispatches each step, watches the feedback, and replans on failure. No orchestration glue from you.
+
+If [Claude Code](https://claude.com/claude-code) is an agentic harness for software engineering, **Cortex is an agentic harness for embodied intelligence**. The capability components -- Vision, VLM, TTS, navigation, memory -- are the robot's limbs and senses. Cortex is the part that decides *what to do next* using these capabilities.
+
+```{seealso}
+For the conceptual model and the full list of capabilities Cortex auto-discovers, see [Cortex](../../intelligence/cortex.md). For Cortex paired with a graph-backed spatio-temporal memory, see [Memory and Cortex](cortex-memory.md). For Cortex orchestrating the navigation stack on top of all of that, see [Cortex Driving the Full Stack](cortex-navigation.md).
+```
+
+---
+
+## The shape of the abstraction
+
+A capability component such as `Vision` exposes its primary work as topics (`/detections`, `/trackings`) but it *also* exposes private methods decorated with `@component_action`:
+
+```python
+class Vision(Component):
+    @component_action(description={...})
+    def track(self, label: str): ...
+
+    @component_action(description={...})
+    def take_picture(self, save_path: str = "..."): ...
+```
+
+These actions are normally invisible -- they require explicit wiring through the events/actions system to be useful. **Cortex changes that.** When you drop a Cortex component into the launcher, on activation it walks every managed component and discovers:
+
+| What gets discovered | What Cortex does with it |
+|---|---|
+| `@component_action` methods | Auto-registers as an LLM tool, namespaced as `{component}.{method}`. Each carries its OpenAI-format description so the planner knows what it does. |
+| `@component_fallback` methods | Same as above -- exposed as callable recovery tools the planner can fall back to. |
+| Additional ROS services (`get_ros_entrypoints()`) | Registered as `send_request_to_{name}`, with the request schema auto-translated to JSON properties so the LLM can fill the fields. |
+| Additional ROS action servers | Registered as `send_goal_to_{name}` with the same schema translation. |
+| The component's main action server | Registered the same way -- so a Planner running as `ActionServer` becomes a callable navigation tool. |
+| Component config parameters | Reachable via the built-in `update_parameter(component, param_name, new_value)` execution tool -- the LLM can re-tune any parameter at runtime. |
+| Component structure | Reachable via the built-in `inspect_component(name)` planning tool -- the LLM reads the recipe live before committing a plan. |
+
+Every one of those tools is automatic. You write the components; Cortex makes them addressable.
+
+---
+
+## What we're building
+
+A robot that, when you tell it *"describe what you see and track the person"*, will:
+
+1. Plan three steps -- call `vlm.describe`, feed its answer to `tts.say`, then dispatch `vision.track`.
+2. Execute them in order -- describing the scene, speaking the description through `tts.say`, then dispatching the long-running tracking action.
+3. Watch the tracking action server's feedback stream and report status.
+
+The recipe is short. There is no event wiring. There are no fallback policies. There are no topic-routed connections between the VLM, the TTS, and Cortex -- speech happens because Cortex calls `tts.say()` as a tool, not because some output topic is silently subscribed by TTS. We don't write a single prompt either -- Cortex's built-in prompts plus the auto-discovered tool descriptions are the prompt.
+
+---
+
+## Step 1: Bring up your capability components
+
+We need eyes, a voice, and visual reasoning. Standard EMOS capability components:
+
+```python
+from agents.clients import OllamaClient, RoboMLRESPClient
+from agents.components import TextToSpeech, VLM, Vision
+from agents.config import TextToSpeechConfig, VisionConfig
+from agents.models import OllamaModel, VisionModel
+from agents.ros import Topic
+
+# Vision — detection + tracking
+detection_model = VisionModel(name="rtdetr", checkpoint="PekingU/rtdetr_r50vd_coco_o365")
+detection_client = RoboMLRESPClient(detection_model)
+
+image_in = Topic(name="/image_raw", msg_type="Image")
+detections = Topic(name="detections", msg_type="Detections")
+trackings = Topic(name="trackings", msg_type="Trackings")
+
+vision = Vision(
+    inputs=[image_in],
+    outputs=[detections, trackings],
+    model_client=detection_client,
+    config=VisionConfig(threshold=0.5),
+    trigger=0.5,
+    component_name="vision",
+)
+
+# VLM — visual question answering. Cortex invokes it via ``vlm.describe``,
+# and the action's return value comes back as the tool result.
+vlm_model = OllamaModel(name="qwen_vl", checkpoint="qwen2.5vl:latest")
+vlm_client = OllamaClient(vlm_model)
+
+vlm_query = Topic(name="vlm_query", msg_type="String")
+vlm_response = Topic(name="vlm_response", msg_type="String")
+
+vlm = VLM(
+    inputs=[vlm_query, image_in],
+    outputs=[vlm_response],
+    model_client=vlm_client,
+    trigger=vlm_query,
+    component_name="vlm",
+)
+
+# TTS — speech happens via Cortex calling ``tts.say(text=...)``.
+tts_input = Topic(name="tts_input", msg_type="String")
+
+tts = TextToSpeech(
+    inputs=[tts_input],
+    config=TextToSpeechConfig(enable_local_model=True, play_on_device=True),
+    trigger=tts_input,
+    component_name="tts",
+)
+```
+
+Nothing here is Cortex-specific. Each component has its own `@component_action` methods declared upstream -- `Vision.track`, `Vision.take_picture`, `VLM.describe`, `TTS.say` -- and Cortex will discover all of them on activation. Cortex sequences the components by calling their actions in turn.
+
+---
+
+## Step 2: Drop in Cortex
+
+```python
+from agents.components import Cortex
+from agents.config import CortexConfig
+from agents.ros import Action
+
+# A planner LLM. Choose a chat-grade model — the smaller, the faster the loop.
+planner_model = OllamaModel(name="qwen", checkpoint="qwen3.5:latest")
+planner_client = OllamaClient(planner_model)
+
+# Cortex publishes its text-only replies (cases where the planner decides no
+# tool calls are needed) to this topic for downstream consumers (e.g. the Web
+# UI). When the planner *does* want the robot to speak, it calls ``tts.say``
+# as a tool -- it does not rely on this topic being subscribed by TTS.
+cortex_output = Topic(name="cortex_output", msg_type="String")
+
+cortex = Cortex(
+    output=cortex_output,
+    model_client=planner_client,
+    config=CortexConfig(max_planning_steps=5, max_execution_steps=10),
+    component_name="cortex",
+)
+```
+
+**That's all.** No `actions=[…]` list -- the capability components contribute their own actions. No prompt -- the built-in prompt plus the discovered tool descriptions are the prompt. No fallback wiring -- Cortex confirms each step before executing it and replans on failure.
+
+---
+
+## Step 3: Adding your own custom action
+
+A capability you want exposed to the planner that doesn't naturally live on a managed component? Pass it as a custom `Action`. Cortex registers it alongside everything else.
+
+```python
+led_on = False
+
+def toggle_led():
+    """Toggle an LED on the robot."""
+    global led_on
+    led_on = not led_on
+    print(f"LED toggled {'ON' if led_on else 'OFF'}")
+
+cortex = Cortex(
+    actions=[
+        Action(method=toggle_led, description="Toggle the robot's LED on or off."),
+    ],
+    output=cortex_output,
+    model_client=planner_client,
+    config=CortexConfig(max_planning_steps=5, max_execution_steps=10),
+    component_name="cortex",
+)
+```
+
+The description is mandatory -- it's what the planner sees when deciding whether to call this tool.
+
+---
+
+## Step 4: Launch
+
+```python
+from agents.ros import Launcher
+
+launcher = Launcher()
+launcher.enable_ui(
+    inputs=[cortex.ui_main_action_input],
+    outputs=[cortex_output],
+)
+launcher.add_pkg(
+    components=[vision, vlm, tts, cortex],
+    multiprocessing=True,
+    package_name="automatika_embodied_agents",
+)
+launcher.on_process_fail()      # process-level safety net
+launcher.bringup()
+```
+
+`launcher.enable_ui` registers a goal-input field for Cortex's main action and a streaming output panel for `cortex_output`. The whole agent runs in a single launcher process tree.
+
+---
+
+## Talking to the agent
+
+Open the Web UI at `http://localhost:5001` and send tasks in plain English:
+
+| Goal | What Cortex plans |
+|---|---|
+| *"describe what you see"* | Two steps: `vlm.describe` produces a sentence; `tts.say` is called with that sentence as its `text` argument. |
+| *"track the person"* | One step: `send_goal_to_track_vision_target(label="person")`. Cortex dispatches the action goal asynchronously and watches its feedback stream until the tracking server reports completion or you cancel. |
+| *"take a picture, describe it, then track whatever's in front of you"* | Three steps, sequenced. The third step's argument is bound from the second step's output -- Cortex resolves `<output from step 2>` placeholders at runtime. |
+| *"toggle the LED"* | One step: the custom `toggle_led` action you registered. |
+| *"are you ok?"* | No actions needed. The planner returns text only; the reply lands on the `cortex_output` topic. (If you want it spoken, your prompt can nudge the planner to always end with a `tts.say` call.) |
+
+Or send a goal from another terminal directly to Cortex's action server:
+
+```shell
+ros2 action send_goal /cortex_<process_id>/cortex_input_command \
+    automatika_embodied_agents/action/VisionLanguageAction \
+    "{task: 'describe what you see and track the person'}"
+```
+
+Watch the launcher's main logging card to see the planning trace, the goals Cortex dispatches, and feedback streamed back from each component.
+
+---
+
+## What just happened
+
+When you sent the goal *"describe what you see and track the person"*, Cortex:
+
+1. Built a plan via the planning loop. The first iteration optionally called `inspect_component("vision")` to confirm the tool surface, then committed three execution tool calls.
+2. Confirmed and dispatched each step. The first (`vlm.describe`) returned a text description; the second (`tts.say`) was called with that description bound as its `text` argument and the speaker spoke it; the third (`send_goal_to_track_vision_target`) was an action goal, dispatched asynchronously. Cortex registered the action client in `_active_action_clients` and the confirmation step started returning `CONTINUE` to wait for tracking feedback rather than barrelling on.
+3. When tracking completed (or you cancelled the high-level goal), the action client was reaped, the episode closed, and the plan returned `SUCCEEDED`.
+
+Compare that to the equivalent recipe written without Cortex: bespoke event wiring for the trigger, hand-tuned prompts on each component, manual action-client construction, manual feedback parsing, manual cancellation. **Cortex collapses all of that into the one component you just dropped in.**
+
+---
+
+## Where next
+
+- {doc}`Cortex Driving the Full Stack <cortex-navigation>` -- the showcase tutorial. Cortex orchestrates a navigation stack, vision, memory, and speech to handle compound natural-language goals like *"go to the kitchen and tell me what's on the counter"*.
+- {doc}`Memory and Cortex <cortex-memory>` -- add a graph-backed spatio-temporal memory so Cortex can reason over past observations and the robot's own internal state.
+- {doc}`Cortex concept page <../../intelligence/cortex>` -- the full reference for the planning loop, the confirmation step, RAG, async goal monitoring, and the Cortex-as-Monitor architecture.

--- a/docs/recipes/planning-and-manipulation/cortex-agent.md
+++ b/docs/recipes/planning-and-manipulation/cortex-agent.md
@@ -43,11 +43,11 @@ Every one of those tools is automatic. You write the components; Cortex makes th
 
 ## What we're building
 
-A robot that, when you tell it *"describe what you see and track the person"*, will:
+A robot that, when you tell it *"describe what you see and then start tracking the person"*, will:
 
-1. Plan three steps -- call `vlm.describe`, feed its answer to `tts.say`, then dispatch `vision.track`.
-2. Execute them in order -- describing the scene, speaking the description through `tts.say`, then dispatching the long-running tracking action.
-3. Watch the tracking action server's feedback stream and report status.
+1. Plan three steps -- call `vlm.describe`, feed its answer to `tts.say`, then call `vision.track`.
+2. Execute them in order -- describing the scene, speaking the description through `tts.say`, then asking `Vision` to start tracking the requested label.
+3. Report each step's result back into the planning loop and close out the episode.
 
 The recipe is short. There is no event wiring. There are no fallback policies. There are no topic-routed connections between the VLM, the TTS, and Cortex -- speech happens because Cortex calls `tts.say()` as a tool, not because some output topic is silently subscribed by TTS. We don't write a single prompt either -- Cortex's built-in prompts plus the auto-discovered tool descriptions are the prompt.
 
@@ -199,7 +199,7 @@ Open the Web UI at `http://localhost:5001` and send tasks in plain English:
 | Goal | What Cortex plans |
 |---|---|
 | *"describe what you see"* | Two steps: `vlm.describe` produces a sentence; `tts.say` is called with that sentence as its `text` argument. |
-| *"track the person"* | One step: `send_goal_to_track_vision_target(label="person")`. Cortex dispatches the action goal asynchronously and watches its feedback stream until the tracking server reports completion or you cancel. |
+| *"start tracking the person"* | One step: `vision.track(label="person")`. The Vision component's `@component_action` starts continuous tracking on the named label (results stream on the `trackings` topic) and returns a confirmation string immediately. |
 | *"take a picture, describe it, then track whatever's in front of you"* | Three steps, sequenced. The third step's argument is bound from the second step's output -- Cortex resolves `<output from step 2>` placeholders at runtime. |
 | *"toggle the LED"* | One step: the custom `toggle_led` action you registered. |
 | *"are you ok?"* | No actions needed. The planner returns text only; the reply lands on the `cortex_output` topic. (If you want it spoken, your prompt can nudge the planner to always end with a `tts.say` call.) |
@@ -218,13 +218,17 @@ Watch the launcher's main logging card to see the planning trace, the goals Cort
 
 ## What just happened
 
-When you sent the goal *"describe what you see and track the person"*, Cortex:
+When you sent the goal *"describe what you see and then start tracking the person"*, Cortex:
 
 1. Built a plan via the planning loop. The first iteration optionally called `inspect_component("vision")` to confirm the tool surface, then committed three execution tool calls.
-2. Confirmed and dispatched each step. The first (`vlm.describe`) returned a text description; the second (`tts.say`) was called with that description bound as its `text` argument and the speaker spoke it; the third (`send_goal_to_track_vision_target`) was an action goal, dispatched asynchronously. Cortex registered the action client in `_active_action_clients` and the confirmation step started returning `CONTINUE` to wait for tracking feedback rather than barrelling on.
-3. When tracking completed (or you cancelled the high-level goal), the action client was reaped, the episode closed, and the plan returned `SUCCEEDED`.
+2. Confirmed and called each step in turn. The first (`vlm.describe`) returned a text description; the second (`tts.say`) was called with that description bound as its `text` argument and the speaker spoke it; the third (`vision.track`) asked the Vision component to start continuous tracking on the named label and returned a confirmation string. Tracking results then streamed on the component's `trackings` topic for any downstream consumer to use.
+3. With every step's tool result folded back into the trace, the episode closed and the plan returned `SUCCEEDED`.
 
-Compare that to the equivalent recipe written without Cortex: bespoke event wiring for the trigger, hand-tuned prompts on each component, manual action-client construction, manual feedback parsing, manual cancellation. **Cortex collapses all of that into the one component you just dropped in.**
+Compare that to the equivalent recipe written without Cortex: bespoke event wiring for the trigger, hand-tuned prompts on each component, manual sequencing of the speech and tracking calls. **Cortex collapses all of that into the one component you just dropped in.**
+
+```{tip}
+For the long-running case -- where Cortex *should* dispatch a Kompass action server like the Controller's `track_vision_target` (or the Planner's `navigate_to_goal`) and watch its feedback stream until the goal completes -- add the `Controller` (or `Planner`) component to the launcher. Cortex auto-registers each one's main action server as `send_goal_to_<server>` and switches into asynchronous monitoring mode. See [Cortex Driving the Full Stack](cortex-navigation.md).
+```
 
 ---
 

--- a/docs/recipes/planning-and-manipulation/cortex-memory.md
+++ b/docs/recipes/planning-and-manipulation/cortex-memory.md
@@ -1,0 +1,279 @@
+# Memory and Cortex
+
+> _"What kind of place have I been in today?"_
+>
+> _"Where did I last see a person?"_
+>
+> _"Are you doing OK? Anything wrong?"_
+>
+> _"Tell me everything you know about the fridge."_
+
+When [Cortex](../../intelligence/cortex.md) and [Memory](../../intelligence/memory.md) share a recipe, the robot becomes addressable in the same way you'd talk to a person who has _been there all day_. Memory accumulates a structured graph of everything the robot has seen, where it saw it, when, and how it was feeling at the time. Cortex auto-discovers Memory's retrieval surface, augments its planning prompt to handle distinct kinds of question, and orchestrates the right tools for each. None of that wiring is yours to write.
+
+This is the recipe that shows what that combination is capable of -- the deep pairing of **the agentic harness** and **the first neuroscience-grounded memory system for embodied agents**.
+
+```{seealso}
+For Memory by itself with no agent on top, start with [Spatio-Temporal Memory](../foundation/semantic-map.md). For Cortex by itself with no memory, start with [Cortex: The Agentic Harness](cortex-agent.md). For the full multi-system showcase that adds navigation on top of this pair, see [Cortex Driving the Full Stack](cortex-navigation.md).
+```
+
+```{admonition} Prerequisites
+:class: important
+
+The `Memory` component requires the [eMEM](https://github.com/automatika-robotics/emem) Python package. Install it into the same environment as the EMOS launcher before running this recipe:
+
+`pip install emem`
+```
+
+---
+
+## What we're building
+
+A robot that, over the course of a session, accumulates a hierarchical record of what it has been doing — and that you can query in three distinct registers:
+
+| Register             | Examples                                                                                                                  | What Cortex does                                                                                                                                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Perception query** | _"Where did you last see the chair?"_, _"What rooms have you been in today?"_, _"Summarise the last 10 minutes"_          | Plans a chain of perception-retrieval tools (`semantic_search`, `temporal_query`, `episode_summary`, `locate`, ...), reads memory's graph, replies in text. **No new observations, no episode wrapping.**                              |
+| **Body query**       | _"How are you feeling?"_, _"What's your battery level?"_, _"Anything overheating?"_                                       | Plans a single `body_status` call. Routes through the dedicated interoception surface (Memory's `is_internal_state=True` layers) — perception tools never see body state and vice versa.                                               |
+| **Action task**      | _"Take a picture of the fridge"_, _"Take a picture of the table and remember what you saw on it"_, _"Patrol the kitchen"_ | **Begins with `body_status`** (refuse the task if internal state says no). Wraps execution in `start_episode` / `end_episode`. Optionally consults perception memory while planning. Stores derived facts via `store_specific_memory`. |
+
+That whole protocol — three registers, mandatory body checks for action tasks, episodic wrapping — is the **Memory-aware planning** Cortex installs automatically when it detects a Memory component in the recipe. You write zero lines of orchestration to get it.
+
+---
+
+## Step 1: Perception
+
+Same Vision + VLM pair as the [foundation memory recipe](../foundation/semantic-map.md) — detections every second, scene captions every ten:
+
+```python
+from agents.clients import OllamaClient
+from agents.components import VLM, Vision
+from agents.config import VisionConfig
+from agents.models import OllamaModel
+from agents.ros import FixedInput, Topic
+
+# Vision component (on-device classifier for low-latency detections)
+image_in = Topic(name="/image_raw", msg_type="Image")
+detections_out = Topic(name="detections", msg_type="Detections")
+
+vision = Vision(
+    inputs=[image_in],
+    outputs=[detections_out],
+    config=VisionConfig(threshold=0.5, enable_local_classifier=True),
+    trigger=1.0,
+    component_name="vision",
+)
+
+# VLM scene captioner — periodic introspective description
+scene_query = FixedInput(
+    name="scene_query",
+    msg_type="String",
+    fixed=(
+        "Describe what you see in one concise sentence: room type, notable "
+        "objects, and any people present."
+    ),
+)
+scene_description = Topic(name="scene_description", msg_type="String")
+
+vlm_model = OllamaModel(name="gemma4", checkpoint="gemma4:latest")
+vlm_client = OllamaClient(vlm_model)
+
+captioner = VLM(
+    inputs=[scene_query, image_in],
+    outputs=[scene_description],
+    model_client=vlm_client,
+    trigger=10.0,
+    component_name="captioner",
+)
+```
+
+These are the **perception layers** Memory will track.
+
+---
+
+## Step 2: Interoception
+
+This is where the Cortex + Memory pairing pulls something the original semantic-map recipe couldn't. We give the robot the ability to feel itself: a battery sensor, a CPU temperature, a joint-health flag — each routed through Memory as an **interoception layer** (`is_internal_state=True`):
+
+```python
+battery_topic = Topic(name="/battery_level", msg_type="Float32")
+cpu_temp_topic = Topic(name="/cpu_temp", msg_type="Float32")
+joint_health_topic = Topic(name="/joint_health", msg_type="String")
+```
+
+```{tip}
+If you don't have a real battery sensor, fake one from another terminal so you can try the body queries below:
+\
+`ros2 topic pub /battery_level std_msgs/msg/Float32 "{data: 42.0}" -r 1`
+```
+
+In Memory, an interoception layer inherits the robot's current pose at write time -- so a low-battery reading taken on a steep ramp is later spatially associated with that ramp.
+
+---
+
+## Step 3: Memory
+
+```python
+from agents.components import Memory
+from agents.config import MemoryConfig
+from agents.ros import MemLayer
+
+position = Topic(name="/odometry/filtered", msg_type="Odometry")
+
+embedding_model = OllamaModel(
+    name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest"
+)
+embedding_client = OllamaClient(embedding_model)
+
+memory = Memory(
+    layers=[
+        # --- Perception layers ---
+        MemLayer(subscribes_to=detections_out, temporal_change=True),
+        MemLayer(subscribes_to=scene_description),
+
+        # --- Interoception layers ---
+        MemLayer(subscribes_to=battery_topic,      is_internal_state=True),
+        MemLayer(subscribes_to=cpu_temp_topic,     is_internal_state=True),
+        MemLayer(subscribes_to=joint_health_topic, is_internal_state=True),
+    ],
+    position=position,
+    model_client=vlm_client,           # used for episode-consolidation gist generation + entity extraction
+    embedding_client=embedding_client, # used for semantic search vector indexing
+    config=MemoryConfig(
+        db_path="/tmp/cortex_memory.db",
+        consolidation_window=300.0,    # short window for the demo so you see consolidation kick in
+        archive_after_seconds=1800.0,
+    ),
+    trigger=10.0,
+    component_name="memory",
+)
+```
+
+A few things worth seeing here:
+
+- **Perception and interoception are peers** — they share the same node/edge graph but get tagged differently so retrieval surfaces stay clean.
+- **`model_client` and `embedding_client` are different clients.** The first writes prose (gists), the second writes vectors. eMEM uses both during consolidation.
+- **`db_path` is the entire memory state.** SQLite-backed eMEM means everything the robot has seen, all entities, all gists, all interoception readings, persist in a single file. **Reboot the robot, point the next session at the same `db_path`, and the agent picks up where it left off.**
+
+---
+
+## Step 4: Voice
+
+Cortex will route its replies straight through TTS so the robot speaks its answers:
+
+```python
+from agents.components import TextToSpeech
+from agents.config import TextToSpeechConfig
+
+tts_in = Topic(name="cortex_output", msg_type="StreamingString")
+
+tts = TextToSpeech(
+    inputs=[tts_in],
+    config=TextToSpeechConfig(enable_local_model=True, play_on_device=True),
+    trigger=tts_in,
+    component_name="tts",
+)
+```
+
+---
+
+## Step 5: Cortex
+
+```python
+from agents.components import Cortex
+from agents.config import CortexConfig
+
+planner_model = OllamaModel(name="qwen", checkpoint="qwen3.5:latest")
+planner_client = OllamaClient(planner_model)
+
+cortex = Cortex(
+    output=tts_in,
+    model_client=planner_client,
+    config=CortexConfig(max_planning_steps=5, max_execution_steps=15),
+    component_name="cortex",
+)
+```
+
+That is the entire agent. When the launcher activates Cortex:
+
+1. It walks every managed component and registers their capabilities.
+2. It detects Memory in the recipe and augments itself to utilize it.
+
+---
+
+## Step 6: Launch
+
+```python
+from agents.ros import Launcher
+
+launcher = Launcher()
+launcher.enable_ui(
+    inputs=[cortex.ui_main_action_input],
+    outputs=[tts_in],
+)
+launcher.add_pkg(
+    components=[vision, captioner, memory, tts, cortex],
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
+)
+launcher.on_process_fail()
+launcher.bringup()
+```
+
+---
+
+## Talking to the robot
+
+Run the recipe and let it sit for a few minutes -- detections accumulate, scene captions roll in every ten seconds, body-state readings are recorded continuously. Open the Web UI at `http://localhost:5001` and start asking questions.
+
+### Perception queries
+
+> _"What is currently around you?"_
+
+The robot replies with what's nearby, drawing on its accumulated memory of the space rather than just the current camera frame.
+
+> _"Where did you last see the chair?"_
+
+You get the location (and roughly when) the chair was last observed.
+
+> _"Summarise everything you've done in the last episode."_
+
+A short summary of the most recent activity span.
+
+> _"Tell me everything you know about the fridge."_
+
+A consolidated answer that fuses every observation, summary, and recognised entity record about the fridge -- across all sessions, including the ones from earlier days.
+
+### Body queries
+
+> _"How are you?"_
+
+The robot reports current battery, CPU temperature, joint health, and any other interoception layer you've wired in.
+
+> _"Is your battery low?"_
+
+Same, filtered to just the battery.
+
+### Action tasks
+
+> _"Walk over and describe the fridge."_
+
+(Assuming you've added a navigation stack -- see [Cortex Driving the Full Stack](cortex-navigation.md) for that pairing.)
+
+The robot first checks its own body state; if the battery is too low or a fault flag is set, it refuses the task and tells you why. Otherwise it recalls where the fridge was last seen, navigates there, takes a fresh look, narrates what it sees, and stores the new description in memory for the next session.
+
+---
+
+## Persistence across sessions
+
+Stop the recipe. Restart it pointing at the same `db_path`. Memory loads the prior session's graph; Cortex re-augments its prompt with the existing layer set; the agent **remembers**.
+
+This is the part of the design that makes eMEM-on-Cortex an actual cognitive system rather than a session-scoped vector DB. _Yesterday's robot is today's robot._ The episodes from yesterday are still in the graph, the entity for the fridge is still there, the gists are still searchable. New observations slot into the same structure.
+
+---
+
+## Where next
+
+- {doc}`Cortex Driving the Full Stack <cortex-navigation>` — pairs this Cortex + Memory recipe with a Kompass navigation stack so the robot can act on memory queries instead of just answering them. Compound goals like _"go to the kitchen and tell me what's on the counter"_ fall out naturally.
+- {doc}`Cortex: The Agentic Harness <cortex-agent>` — the introductory tutorial focused on Cortex's auto-discovery and tool surface, without Memory.
+- {doc}`Memory concept page <../../intelligence/memory>` — the full architectural reference for eMEM.
+- [eMEM on GitHub](https://github.com/automatika-robotics/emem) — the underlying memory library, including a standalone testing harness with a MiniGrid environment and a ReAct agent that exercises memory's tools end-to-end.

--- a/docs/recipes/planning-and-manipulation/cortex-memory.md
+++ b/docs/recipes/planning-and-manipulation/cortex-memory.md
@@ -127,7 +127,7 @@ embedding_client = OllamaClient(embedding_model)
 memory = Memory(
     layers=[
         # --- Perception layers ---
-        MemLayer(subscribes_to=detections_out, temporal_change=True),
+        MemLayer(subscribes_to=detections_out),
         MemLayer(subscribes_to=scene_description),
 
         # --- Interoception layers ---

--- a/docs/recipes/planning-and-manipulation/cortex-navigation.md
+++ b/docs/recipes/planning-and-manipulation/cortex-navigation.md
@@ -1,0 +1,321 @@
+# Cortex Driving the Full Stack
+
+This is the tutorial that shows what [Cortex](../../intelligence/cortex.md) is *for*. We give a robot eyes, a voice, a body that can move, and a memory that learns. Then we drop a Cortex on top of all of that and start typing compound, free-form goals into the Web UI:
+
+> *"Go to the kitchen and tell me what's on the counter."*
+>
+> *"Find the closest chair, take a picture there, and come back here."*
+>
+> *"Patrol the room until you see a person, then announce their location."*
+
+There is no parser, no state machine, no sequence diagram in this recipe. Cortex inspects the running graph, plans the steps, dispatches navigation goals, watches their feedback, calls a VLM to look at the world when it arrives, queries Memory for what it has seen before, and routes its replies through TTS so the robot speaks. **The recipe is the graph; the agent is one master component.**
+
+```{seealso}
+For the introduction to the Cortex abstraction itself, start with [Cortex: The Agentic Harness](cortex-agent.md). For the conceptual reference covering the full feature set Cortex auto-discovers, see [Cortex](../../intelligence/cortex.md). For Cortex without a navigation stack, focused on the deep pairing with spatio-temporal memory, see [Memory and Cortex](cortex-memory.md).
+```
+
+---
+
+## What we're orchestrating
+
+Five subsystems, all running in one launcher:
+
+| Subsystem | Components | What Cortex does with it |
+|---|---|---|
+| **Perception** | `Vision`, `VLM` | Detection feeds Memory; VLM answers visual questions on demand. |
+| **Spatial memory** | `Memory` | Stores detections + scene captions tagged with position. Exposes `locate`, `recall`, `semantic_search`, `body_status`, ten retrieval tools in total. |
+| **Voice** | `TextToSpeech` | The robot's mouthpiece. Cortex routes its replies straight through. |
+| **Navigation** | `Planner`, `Controller`, `LocalMapper`, `DriveManager` | The Kompass quartet. Cortex sends action goals to `Planner`'s main action server. |
+| **The agent** | `Cortex` | Discovers all of the above, exposes them as LLM tools, plans and executes against natural-language goals. |
+
+The wiring is conventional EMOS. The Cortex section at the end is what turns the whole stack into a single self-directing agent.
+
+---
+
+## Step 1: Robot configuration
+
+Standard differential-drive setup; adjust to your platform.
+
+```python
+import numpy as np
+from kompass.robot import (
+    AngularCtrlLimits,
+    LinearCtrlLimits,
+    RobotConfig,
+    RobotFrames,
+    RobotGeometry,
+    RobotType,
+)
+
+my_robot = RobotConfig(
+    model_type=RobotType.DIFFERENTIAL_DRIVE,
+    geometry_type=RobotGeometry.Type.CYLINDER,
+    geometry_params=np.array([0.1, 0.3]),
+    ctrl_vx_limits=LinearCtrlLimits(max_vel=0.4, max_acc=1.5, max_decel=2.5),
+    ctrl_omega_limits=AngularCtrlLimits(
+        max_vel=0.4, max_acc=2.0, max_decel=2.0, max_steer=np.pi / 3
+    ),
+)
+```
+
+---
+
+## Step 2: The navigation stack
+
+```python
+from kompass.components import (
+    Controller,
+    DriveManager,
+    LocalMapper,
+    LocalMapperConfig,
+    Planner,
+    PlannerConfig,
+)
+from kompass.control import ControllersID, MapConfig
+from kompass.ros import Topic
+
+# Planner — runs as an Action Server so Cortex can dispatch goals into it.
+planner = Planner(component_name="planner", config=PlannerConfig(loop_rate=1.0))
+planner.run_type = "ActionServer"
+
+# Controller — DWA, eats from the local map.
+controller = Controller(component_name="controller")
+controller.algorithm = ControllersID.DWA
+controller.direct_sensor = False
+
+# DriveManager
+driver = DriveManager(component_name="drive_manager")
+driver.outputs(robot_command=Topic(name="/cmd_vel", msg_type="Twist"))
+
+# Local Mapper — fed by a 2D laser
+local_mapper = LocalMapper(
+    component_name="mapper",
+    config=LocalMapperConfig(
+        map_params=MapConfig(width=4.0, height=4.0, resolution=0.1),
+    ),
+)
+local_mapper.inputs(sensor_data=Topic(name="/scan", msg_type="LaserScan"))
+```
+
+---
+
+## Step 3: Perception
+
+```python
+from agents.clients import OllamaClient
+from agents.components import VLM, Vision
+from agents.config import VisionConfig
+from agents.models import OllamaModel
+from agents.ros import FixedInput
+
+image_in = Topic(name="/image_raw", msg_type="Image")
+detections_out = Topic(name="detections", msg_type="Detections")
+
+vision = Vision(
+    inputs=[image_in],
+    outputs=[detections_out],
+    config=VisionConfig(threshold=0.5, enable_local_classifier=True),
+    trigger=1.0,
+    component_name="vision",
+)
+
+# A VLM that captions every 10 seconds — the captions feed Memory and TTS.
+scene_query = FixedInput(
+    name="scene_query",
+    msg_type="String",
+    fixed="Describe the scene in one concise sentence: room type and notable objects.",
+)
+scene_description = Topic(name="scene_description", msg_type="String")
+
+vlm_model = OllamaModel(name="gemma4", checkpoint="gemma4:latest")
+vlm_client = OllamaClient(vlm_model)
+
+captioner = VLM(
+    inputs=[scene_query, image_in],
+    outputs=[scene_description],
+    model_client=vlm_client,
+    trigger=10.0,
+    component_name="captioner",
+)
+```
+
+The VLM's `describe` and Vision's `track` / `take_picture` are `@component_action`s already declared upstream. **Cortex will discover them all.** We don't wire any of them by hand.
+
+---
+
+## Step 4: Memory
+
+```python
+from agents.components import Memory
+from agents.config import MemoryConfig
+from agents.ros import MemLayer
+
+position = Topic(name="/odometry/filtered", msg_type="Odometry")
+
+embedding_model = OllamaModel(
+    name="embeddings", checkpoint="nomic-embed-text-v2-moe:latest"
+)
+embedding_client = OllamaClient(embedding_model)
+
+memory = Memory(
+    layers=[
+        MemLayer(subscribes_to=detections_out, temporal_change=True),
+        MemLayer(subscribes_to=scene_description),
+    ],
+    position=position,
+    model_client=vlm_client,
+    embedding_client=embedding_client,
+    config=MemoryConfig(db_path="/tmp/embodied_memory.db"),
+    trigger=10.0,
+    component_name="memory",
+)
+```
+
+When Memory is in the recipe, Cortex **automatically augments itself** with task-classification guidance. Action tasks get wrapped in episodes -- Cortex begins them with `start_episode` and ends with `end_episode` so the observations made during the task get consolidated into the long-term graph.
+
+```{tip}
+Add an interoception layer (`MemLayer(subscribes_to=battery_topic, is_internal_state=True)`) and Cortex starts every action plan with a `body_status` check -- it might refuse to navigate when the battery is below a threshold, with a clear text explanation. See [Memory and Cortex](cortex-memory.md) for the full pattern.
+```
+
+---
+
+## Step 5: Voice
+
+```python
+from agents.components import TextToSpeech
+from agents.config import TextToSpeechConfig
+
+tts_in = Topic(name="cortex_output", msg_type="StreamingString")
+
+tts = TextToSpeech(
+    inputs=[tts_in],
+    config=TextToSpeechConfig(enable_local_model=True, play_on_device=True),
+    trigger=tts_in,
+    component_name="tts",
+)
+```
+
+---
+
+## Step 6: Cortex
+
+```python
+from agents.components import Cortex
+from agents.config import CortexConfig
+
+planner_model = OllamaModel(name="qwen", checkpoint="qwen3.5:latest")
+planner_client = OllamaClient(planner_model)
+
+cortex = Cortex(
+    output=tts_in,                # Cortex streams replies into TTS
+    model_client=planner_client,
+    config=CortexConfig(
+        max_planning_steps=5,
+        max_execution_steps=15,
+    ),
+    component_name="cortex",
+)
+```
+
+That's the whole agent. **No `actions=[...]` is needed** -- the agent's tool palette is everything the other components contribute:
+
+If you want to add a private capability that isn't on a managed component -- a database call, a custom servo on a peripheral, an external API -- pass it as a custom `Action(method=..., description=...)` in `actions=[...]` and Cortex registers it alongside the rest.
+
+---
+
+## Step 7: Launch
+
+```python
+from kompass.ros import Launcher
+
+launcher = Launcher()
+
+# Navigation stack
+launcher.add_pkg(
+    components=[planner, controller, driver, local_mapper],
+    multiprocessing=True,
+    package_name="kompass",
+)
+
+# Intelligence stack
+launcher.add_pkg(
+    components=[vision, captioner, memory, tts, cortex],
+    multiprocessing=True,
+    package_name="automatika_embodied_agents",
+)
+
+# Shared inputs
+launcher.inputs(location=position)
+
+# Robot config + frames
+launcher.robot = my_robot
+launcher.frames = RobotFrames(world="map", odom="odom", scan="base_scan")
+
+launcher.enable_ui(
+    inputs=[cortex.ui_main_action_input],
+    outputs=[tts_in],
+)
+
+launcher.on_process_fail()
+launcher.bringup()
+```
+
+---
+
+## Driving the agent
+
+Run the recipe and let the robot wander around for a few minutes. Memory accumulates detections and scene captions tagged with positions. Then open `http://localhost:5001` and start typing.
+
+### Single-step goals
+
+> *"What is currently around you?"* — the robot describes its surroundings.
+>
+> *"Where did you last see the chair?"* — gives the location and roughly when.
+>
+> *"How are you?"* — reads its body state and replies.
+
+### Compound goals -- the interesting case
+
+> *"Go to the chair."*
+
+The robot recalls where the chair is from memory, dispatches a navigation goal, and reports when it has arrived.
+
+> *"Go to the kitchen and tell me what's on the counter."*
+
+The robot navigates to the kitchen using its memory of where that is, looks at the counter once it arrives, narrates what it sees, and stores the new observation in memory for the next session.
+
+> *"Patrol the room. If you see a person, stop and tell me where you found them."*
+
+A long-horizon mission. The robot dispatches successive navigation goals around the room and watches its detections. The moment a person appears, it cancels the current goal and reports their location.
+
+None of these required you to write orchestration code, prompts, or a state machine. The behaviour emerges from Cortex's read of the auto-discovered tool surface and the memory-aware planning it installs when it sees a Memory component in the recipe.
+
+---
+
+## What this looks like in the Web UI
+
+Send a goal, and the action goal Cortex dispatches into the Planner appears live as feedback in the **main logging card** -- both the Planner's path-tracking feedback and Cortex's own confirmation decisions stream side by side.
+
+---
+
+## What you didn't have to write
+
+- An event triggering "go to X" when the user types it.
+- An LLM prompt parsing "go to X" into a destination.
+- A goal-builder for the Planner action.
+- An action client construction with feedback callbacks and cancellation logic.
+- A retry policy for the navigation goal.
+- A wait-loop that blocks until SUCCEEDED before invoking the VLM.
+- A handoff from the VLM output to the TTS input.
+- A memory write that records "I went to the kitchen and saw X".
+
+That entire stack of orchestration is replaced by the auto-discovery, the two-phase loop, and the Memory-aware prompt augmentation. **You wrote the components. Cortex wrote the recipe.**
+
+---
+
+## Where next
+
+- {doc}`Cortex concept page <../../intelligence/cortex>` -- a deeper look at the auto-discovery, the planning/execution loop, RAG, and the Cortex-as-Monitor model.
+- {doc}`Memory and Cortex <cortex-memory>` -- the same agentic harness focused entirely on memory: episodic consolidation, entity tracking, interoception layers, and how Cortex reasons over them.
+- {doc}`Cortex: The Agentic Harness <cortex-agent>` -- the introductory tutorial if you want to start with a smaller graph before scaling up to navigation.
+- {doc}`Visualizing the System Graph <../events-and-resilience/visualizing-system-graph>` -- watch the System Graph render Cortex's tool palette and the goal-status events flowing through it.

--- a/docs/recipes/planning-and-manipulation/cortex-navigation.md
+++ b/docs/recipes/planning-and-manipulation/cortex-navigation.md
@@ -159,7 +159,7 @@ embedding_client = OllamaClient(embedding_model)
 
 memory = Memory(
     layers=[
-        MemLayer(subscribes_to=detections_out, temporal_change=True),
+        MemLayer(subscribes_to=detections_out),
         MemLayer(subscribes_to=scene_description),
     ],
     position=position,

--- a/docs/recipes/planning-and-manipulation/index.md
+++ b/docs/recipes/planning-and-manipulation/index.md
@@ -1,31 +1,52 @@
 # Planning & Manipulation Overview
 
-Bridge the gap between high-level reasoning and physical actuation. These recipes demonstrate VLM-based planning and VLA-based end-to-end robotic manipulation.
+Bridge the gap between high-level reasoning and physical actuation. These recipes cover [Cortex](../../intelligence/cortex.md) -- the EMOS planner-executor that decomposes goals into ordered tool calls, dispatches them, and replans on failure, all on top of capability components you wrote in isolation -- alongside VLM-based planning and VLA-based end-to-end manipulation for direct motor control.
 
 ---
 
 ::::{grid} 1 2 3 3
 :gutter: 3
 
+:::{grid-item-card} {material-regular}`smart_toy;1.2em;sd-text-primary` Cortex: The Agentic Harness
+:link: cortex-agent
+:link-type: doc
+
+A component that sits on top of the rest of your recipe and turns it into a self-directing agent. Cortex auto-discovers every components capabilities and uses them to acheive a high level goal.
+:::
+
+:::{grid-item-card} {material-regular}`memory;1.2em;sd-text-primary` Memory and Cortex
+:link: cortex-memory
+:link-type: doc
+
+Cortex paired with graph-backed spatio-temporal memory. It recalls past observations, reason about internal state via interoception, and wrap action tasks in episodes that consolidate into long-term memory.
+:::
+
+:::{grid-item-card} {material-regular}`route;1.2em;sd-text-primary` Cortex Driving the Full Stack
+:link: cortex-navigation
+:link-type: doc
+
+The full stack. Cortex orchestrates Vision, VLM, Memory, the Kompass navigation stack, and TTS end-to-end. Compound goals fulfille by a single agent -- no behavior trees, no state machines.
+:::
+
 :::{grid-item-card} {material-regular}`psychology;1.2em;sd-text-primary` Multimodal Planning
 :link: planning-models
 :link-type: doc
 
-Use a VLM to decompose complex instructions into executable low-level actions.
+Navigation guided by sight, not maps. A planning VLM grounds free-form descriptions like *"the yellow chair"* in the live camera frame and projects them into goal points the navigation stack acts on.
 :::
 
 :::{grid-item-card} {material-regular}`precision_manufacturing;1.2em;sd-text-primary` VLA Manipulation
 :link: vla-manipulation
 :link-type: doc
 
-Map visual inputs directly to joint commands using Vision-Language-Action models.
+End-to-end neural manipulation. Use one of the latest VLA foundation models -- SmolVLA, Pi0, or any other policy from the HuggingFace LeRobot ecosystem -- and go straight from camera frames + text to joint commands.
 :::
 
 :::{grid-item-card} {material-regular}`loop;1.2em;sd-text-primary` Event-Driven VLA
 :link: event-driven-vla
 :link-type: doc
 
-Closed-loop manipulation -- a VLM referee stops actions on visual task completion.
+Closed-loop manipulation from an open-loop policy. A VLM watches the camera during execution and stops the VLA the moment it sees the task complete -- or sees it going wrong.
 :::
 
 ::::

--- a/docs/recipes/planning-and-manipulation/index.md
+++ b/docs/recipes/planning-and-manipulation/index.md
@@ -11,21 +11,21 @@ Bridge the gap between high-level reasoning and physical actuation. These recipe
 :link: cortex-agent
 :link-type: doc
 
-A component that sits on top of the rest of your recipe and turns it into a self-directing agent. Cortex auto-discovers every components capabilities and uses them to acheive a high level goal.
+A component that sits on top of the rest of your recipe and turns it into a self-directing agent. Cortex auto-discovers every component's capabilities and uses them to achieve a high-level goal.
 :::
 
 :::{grid-item-card} {material-regular}`memory;1.2em;sd-text-primary` Memory and Cortex
 :link: cortex-memory
 :link-type: doc
 
-Cortex paired with graph-backed spatio-temporal memory. It recalls past observations, reason about internal state via interoception, and wrap action tasks in episodes that consolidate into long-term memory.
+Cortex paired with graph-backed spatio-temporal memory. It recalls past observations, reasons about internal state via interoception, and wraps action tasks in episodes that consolidate into long-term memory.
 :::
 
 :::{grid-item-card} {material-regular}`route;1.2em;sd-text-primary` Cortex Driving the Full Stack
 :link: cortex-navigation
 :link-type: doc
 
-The full stack. Cortex orchestrates Vision, VLM, Memory, the Kompass navigation stack, and TTS end-to-end. Compound goals fulfille by a single agent -- no behavior trees, no state machines.
+The full stack. Cortex orchestrates Vision, VLM, Memory, the Kompass navigation stack, and TTS end-to-end. Compound goals fulfilled by a single agent -- no behavior trees, no state machines.
 :::
 
 :::{grid-item-card} {material-regular}`psychology;1.2em;sd-text-primary` Multimodal Planning

--- a/docs/recipes/planning-and-manipulation/planning-models.md
+++ b/docs/recipes/planning-and-manipulation/planning-models.md
@@ -102,7 +102,7 @@ config = VLMConfig(task="grounding")
 
 # initialize the component
 go_to_x = VLM(
-    inputs=[llm_output, rgbd],
+    inputs=[llm_output, rgbd0],
     outputs=[grounding_output],
     model_client=robobrain_client,
     trigger=llm_output,

--- a/docs/recipes/planning-and-manipulation/planning-models.md
+++ b/docs/recipes/planning-and-manipulation/planning-models.md
@@ -59,7 +59,7 @@ RoboML is an aggregator library that provides a model serving apparatus for loca
 
 The RoboBrain models are gated repositories on HuggingFace. To avoid "model not authorized" or `401 Client Error` messages:
 
-1. **Agree to Terms:** You must sign in to your HuggingFace account and accept the license terms on the [model's repository page](https://huggingface.co/BAAI/RoboBrain2.0-7B).
+1. **Agree to Terms:** You must sign in to your HuggingFace account and accept the license terms on the [model's repository page](https://huggingface.co/BAAI/RoboBrain2.0-3B) (or the variant you choose).
 2. **Authenticate Locally:** Ensure your environment is authenticated by running `huggingface-cli login` in your terminal and entering your access token.
 ```
 
@@ -150,7 +150,7 @@ my_robot = RobotConfig(
 Now we can add our default components. Our component of interest is the _planning_ component, that plots a path to the goal point. We will give the output topic from our VLM component as the goal point topic to the planning component.
 
 ```{important}
-While planning components typically require goal points as `Pose` or `PoseStamped` messages in world space, EMOS also accepts `Detection` and `PointOfInterest` messages from EmbodiedAgents. These contain pixel-space coordinates identified by ML models. When generated from RGBD inputs, the associated depth images are included, enabling EMOS to automatically convert pixel-space points to averaged world-space coordinates using camera intrinsics.
+The Kompass Planner accepts `Detections`, `PointsOfInterest`, and `Trackings` messages from EmbodiedAgents directly as goal-point inputs. These contain pixel-space coordinates identified by ML models. When generated from RGBD inputs, the associated depth images enable Kompass to automatically convert pixel-space points to averaged world-space coordinates using camera intrinsics. See [Planning](../../navigation/planning.md) for the supported input types.
 ```
 
 ```python
@@ -188,18 +188,24 @@ Learn the details of point navigation in EMOS using the step-by-step [Point Navi
 Now we will launch our Go-to-X component and navigation components using the same launcher.
 
 ```python
-from kompass.launcher import Launcher
+from kompass.ros import Launcher
 
 launcher = Launcher()
 
 # Add the intelligence components
-launcher.add_pkg(components=[sentence_parser, go_to_x], ros_log_level="warn",
-                 package_name="automatika_embodied_agents",
-                 executable_entry_point="executable",
-                 multiprocessing=True)
+launcher.add_pkg(
+    components=[sentence_parser, go_to_x],
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
+    ros_log_level="warn",
+)
 
 # Add the navigation components
-launcher.kompass(components=[planner, controller, mapper, driver])
+launcher.add_pkg(
+    components=[planner, controller, mapper, driver],
+    package_name="kompass",
+    multiprocessing=True,
+)
 
 # Set the robot config for all components as defined above and bring up
 launcher.robot = my_robot
@@ -233,7 +239,7 @@ from kompass.components import (
     DriveManager,
     LocalMapper,
 )
-from kompass.launcher import Launcher
+from kompass.ros import Launcher
 
 
 # Start a Llama3.2 based llm component using ollama client
@@ -305,13 +311,19 @@ driver = DriveManager(component_name="drive_manager")
 launcher = Launcher()
 
 # Add the intelligence components
-launcher.add_pkg(components=[sentence_parser, go_to_x], ros_log_level="warn",
-                 package_name="automatika_embodied_agents",
-                 executable_entry_point="executable",
-                 multiprocessing=True)
+launcher.add_pkg(
+    components=[sentence_parser, go_to_x],
+    package_name="automatika_embodied_agents",
+    multiprocessing=True,
+    ros_log_level="warn",
+)
 
 # Add the navigation components
-launcher.kompass(components=[planner, controller, mapper, driver])
+launcher.add_pkg(
+    components=[planner, controller, mapper, driver],
+    package_name="kompass",
+    multiprocessing=True,
+)
 
 # Set the robot config for all components as defined above and bring up
 launcher.robot = my_robot

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,6 @@ sphinx-autodoc2
 sphinx-copybutton
 sphinx-design
 sphinx-sitemap
+sphinxcontrib-mermaid>=1.0.0
 myst-parser
 linkify-it-py


### PR DESCRIPTION
## Summary

Refreshes the EMOS docs to match the stack submodule bump (embodied-agents `0.7.3`, kompass `0.5.0`, sugarcoat `0.7.0+1`). Adds first-class concept pages and hands-on recipes for the two new components -- **Cortex** (agentic harness) and **Memory** (graph-backed spatio-temporal memory built on eMEM) -- and brings every existing recipe into line with the post-bump APIs.

## New concept pages

- `docs/intelligence/cortex.md` -- Cortex as the planner-executor that auto-discovers every other component's `@component_action` / `@component_fallback` methods and exposes them as LLM tools. Two-phase planning/execution loop, EXECUTE/SKIP/ABORT/CONTINUE confirmation, replanning on failure, Monitor role.
- `docs/intelligence/memory.md` -- Memory as a graph indexed simultaneously by meaning (HNSW), location (R-tree) and time (SQLite). Four node types, six edge types, working -> short-term -> long-term -> archived consolidation tiers, and the perception-vs-interoception `MemLayer` distinction.

## New recipes

- `docs/recipes/planning-and-manipulation/cortex-agent.md` -- Cortex on its own: drop one component on top of a couple of capability components and the recipe becomes a self-directed agent.
- `docs/recipes/planning-and-manipulation/cortex-memory.md` -- Cortex paired with Memory: persistence across reboots, perception layers vs internal-state layers, how Cortex consumes Memory's actions during planning.
- `docs/recipes/planning-and-manipulation/cortex-navigation.md` -- Cortex driving the full stack on a mobile robot, including kompass-side action calls.
- `docs/recipes/events-and-resilience/internal-state-events.md` -- Generic `Event(callable, check_rate=N.0)` against an internal-state callable, no topic required.
- `docs/recipes/events-and-resilience/visualizing-system-graph.md` -- Renamed and reframed from the old "visualizing-events" recipe to cover the whole System Graph view, not just events; embeds the `system_ui.gif`.

## Updated recipes

- `docs/recipes/foundation/complete-agent.md` -- Mermaid flowchart of the agent (red `classDef` on EMOS components only, ChromaDB regrouped as a backend, bidirectional component<->model arrows).
- `docs/recipes/foundation/tool-calling.md` -- Demo replaced with `get_weather` against the public Open-Meteo API plus `send_tool_response_to_model=True`; clarifies that both `OllamaClient` and `GenericHTTPClient` support tool calling.
- `docs/recipes/foundation/semantic-map.md`, `complete-agent.md`, `goto-navigation.md`, `prompt-engineering.md`, `conversational-agent.md` -- Updated for the new Memory API (`MemLayer`, `is_internal_state`, `register_tools_on`) and the new RoboML model wrappers (`VisionModel` w/ HF Transformers detection, `TransformersTTS` defaulting to `facebook/mms-tts-eng`, `RoboBrain2` defaulting to `BAAI/RoboBrain2.0-3B`, `Whisper` defaulting to `small.en`). All `mmdetection`, `SpeechT5` and `RoboBrain2.0-7B` references removed.
- `docs/recipes/navigation/vision-tracking-rgb.md` and `vision-tracking-depth.md` -- Refreshed for the controller refactor: `ControllersID.VISION_IMG` / `VISION_DEPTH` plus `VisionRGBFollowerConfig` / `VisionRGBDFollowerConfig`.
- `docs/recipes/planning-and-manipulation/planning-models.md` -- Imports updated for the removed `kompass.launcher` module (Launcher now re-exported via `kompass.ros`).
- `docs/recipes/events-and-resilience/multiprocessing.md` -- Restructured around `on_process_fail` / process-level recovery layered under the existing component-level fallbacks.

## Updated concepts

- `docs/concepts/events-and-actions.md` -- New "Events from Internal State" subsection covering the generic Python-callable event mechanism, placed before Actions.
- `docs/concepts/status-and-fallbacks.md` -- New "Process-Level Recovery" section covering `Launcher.on_process_fail` and `BaseComponent.safe_restart`.
- `docs/concepts/web-ui.md` -- Adds System Graph view, action-server logs in the main logging card, and the no-map geometry element.
- `docs/concepts/launcher.md` -- Notes `on_process_fail`, `executor_spin_timeout`, and `execute_method` returning the called method's response.
- `docs/navigation/planning.md`, `control.md` -- Planner now accepts `Detections` / `PointsOfInterest` / `Trackings` as goal sources; quaternion fix for goal orientation; `reached_end` no longer spammed; controller `_update_state` / `_update_sensor_data` split.

## Overview & landing pages

- `docs/recipes/overview.md` -- "Recipe Examples" reframed around five real-world deployments (Warehouse Auditor, Home Care Companion, Last-Mile Delivery Worker, 24/7 Security Patrol, Off-Grid Field Mule), each linked to the recipe that backs the showcased capability.
- `docs/intelligence/overview.md` -- "What You Can Build" card grid revised to feature Cortex/Memory framing rooted in real-world robot scenarios.
- `docs/recipes/planning-and-manipulation/index.md` -- Six cards: three Cortex recipes plus revised descriptions for multimodal planning, VLA manipulation (now mentioning SmolVLA / Pi0 / HuggingFace LeRobot), and event-driven VLA.
- `docs/intelligence/ai-components.md` -- Memory grouped with capability components (LLM, VLM, etc.); Cortex called out as the only planner-executor.

## Build infrastructure

- `docs/conf.py` -- `sphinxcontrib.mermaid` extension wired in, `mermaid_version = "latest"` (CDN-loaded; no build-time `mmdc` needed on the runner), Architects Daughter font for diagrams; `LLMS_TXT_SELECTION` updated for the new pages and the renamed visualizing recipe; LLMs preamble pared back to the canonical six-step shape.
- `docs/requirements.txt` -- adds `sphinxcontrib-mermaid>=1.0.0`.
- `docs/_static/custom.css` -- Mermaid handwritten-font rule (Architects Daughter, 19px, weight 700).