### PR TITLE
(feat) Surface "update available" indicator in CLI and dashboard

### DIFF
--- a/stack/emos-cli/cmd/root.go
+++ b/stack/emos-cli/cmd/root.go
@@ -25,6 +25,7 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ui.Banner(config.Version)
 		ui.StatusCard(config.Version)
+		printUpdateAvailable()
 	},
 }
 

--- a/stack/emos-cli/cmd/status.go
+++ b/stack/emos-cli/cmd/status.go
@@ -19,6 +19,7 @@ var statusCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ui.Banner(config.Version)
 		ui.StatusCard(config.Version)
+		printUpdateAvailable()
 
 		cfg := config.LoadConfig()
 		if !cfg.IsInstalled() {

--- a/stack/emos-cli/cmd/update.go
+++ b/stack/emos-cli/cmd/update.go
@@ -20,16 +20,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// updateCheckTTL bounds how often the CLI hits GitHub for the cached
-// "latest release" value. Currently set to 6h to not irritate the rate-limiter
-const updateCheckTTL = 6 * time.Hour
-
 // printUpdateAvailable consults the cached latest-release tag and, if it
 // names a strictly newer version than this binary, prints a one-line
 // nudge. Silent on dev builds, or when no value is cached yet or on parse
-// failures. Called by `emos status` and `emos version`
+// failures. Called by `emos status` and `emos version`.
 func printUpdateAvailable() {
-	latest, ok := updcheck.RefreshIfStale(updateCheckTTL)
+	latest, ok := updcheck.RefreshIfStale(updcheck.DefaultRefreshInterval)
 	if !ok || !updcheck.IsNewer(config.Version, latest) {
 		return
 	}

--- a/stack/emos-cli/cmd/update.go
+++ b/stack/emos-cli/cmd/update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,15 +9,33 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
+	"time"
 
 	"github.com/automatika-robotics/emos-cli/internal/api"
 	"github.com/automatika-robotics/emos-cli/internal/config"
 	"github.com/automatika-robotics/emos-cli/internal/container"
 	"github.com/automatika-robotics/emos-cli/internal/installer"
 	"github.com/automatika-robotics/emos-cli/internal/ui"
+	"github.com/automatika-robotics/emos-cli/internal/updcheck"
 	"github.com/spf13/cobra"
 )
+
+// updateCheckTTL bounds how often the CLI hits GitHub for the cached
+// "latest release" value. Currently set to 6h to not irritate the rate-limiter
+const updateCheckTTL = 6 * time.Hour
+
+// printUpdateAvailable consults the cached latest-release tag and, if it
+// names a strictly newer version than this binary, prints a one-line
+// nudge. Silent on dev builds, or when no value is cached yet or on parse
+// failures. Called by `emos status` and `emos version`
+func printUpdateAvailable() {
+	latest, ok := updcheck.RefreshIfStale(updateCheckTTL)
+	if !ok || !updcheck.IsNewer(config.Version, latest) {
+		return
+	}
+	ui.Faint(fmt.Sprintf("→ Update available: v%s (current v%s) -- run 'emos update'",
+		latest, config.Version))
+}
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
@@ -74,13 +93,24 @@ func selfUpdateCLI() (bool, error) {
 
 	ui.Info("Checking for CLI updates...")
 
-	// Fetch latest release info
-	resp, err := http.Get(config.ReleasesURL())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	latestVersion, err := updcheck.Latest(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to check releases: %w", err)
 	}
-	defer resp.Body.Close()
+	if latestVersion == config.Version {
+		ui.Success("CLI is already up to date (v" + config.Version + ")")
+		return false, nil
+	}
 
+	// We still need the asset list to find the right per-arch binary, so
+	// hit /releases/latest a second time
+	resp, err := http.Get(config.ReleasesURL())
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch release assets: %w", err)
+	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return false, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
 	}
@@ -94,12 +124,6 @@ func selfUpdateCLI() (bool, error) {
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
 		return false, fmt.Errorf("failed to parse release: %w", err)
-	}
-
-	latestVersion := strings.TrimPrefix(release.TagName, "v")
-	if latestVersion == config.Version {
-		ui.Success("CLI is already up to date (v" + config.Version + ")")
-		return false, nil
 	}
 
 	// Find the binary for current architecture

--- a/stack/emos-cli/internal/server/handlers_info.go
+++ b/stack/emos-cli/internal/server/handlers_info.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/automatika-robotics/emos-cli/internal/config"
+	"github.com/automatika-robotics/emos-cli/internal/updcheck"
 )
 
 // handleHealth is a cheap liveness probe for systemd, the dashboard, and any
@@ -50,6 +51,14 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 		if s.cfg.LicenseKey != "" {
 			resp["license_present"] = true
 		}
+	}
+	// NOTE: Latest release tag is populated by the background refresh goroutine
+	// in server.go. Stays absent until the first successful fetch so a
+	// schema-aware client (the SPA) can distinguish "no value yet" from
+	// "up-to-date".
+	if latest, _ := s.updates.Snapshot(); latest != "" {
+		resp["latest_version"] = latest
+		resp["update_available"] = updcheck.IsNewer(config.Version, latest)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/stack/emos-cli/internal/server/handlers_info_test.go
+++ b/stack/emos-cli/internal/server/handlers_info_test.go
@@ -103,6 +103,53 @@ func TestHandleCapabilities(t *testing.T) {
 	}
 }
 
+// /info MUST omit latest_version / update_available before the daemon's
+// background refresh goroutine has successfully populated the cache --
+// otherwise an offline-first boot leaks a stale `false` to the SPA.
+func TestHandleInfo_OmitsUpdateFields_BeforeRefresh(t *testing.T) {
+	s := newTestServer(t, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/info", nil)
+	rec := httpServe(t, s, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body map[string]any
+	jsonBody(t, rec, &body)
+	for _, key := range []string{"latest_version", "update_available"} {
+		if _, ok := body[key]; ok {
+			t.Errorf("%s present before first refresh: %+v", key, body)
+		}
+	}
+}
+
+func TestHandleInfo_EmitsUpdateFields_AfterRefresh(t *testing.T) {
+	s := newTestServer(t, false)
+	// Pretend the background goroutine has succeeded; current config.Version
+	// is a real X.Y.Z baked at build time, and we name a guaranteed-newer
+	// tag so the IsNewer check returns true regardless of the build tag.
+	s.updates.set("999.0.0")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/info", nil)
+	rec := httpServe(t, s, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body map[string]any
+	jsonBody(t, rec, &body)
+	if body["latest_version"] != "999.0.0" {
+		t.Errorf("latest_version = %v, want 999.0.0", body["latest_version"])
+	}
+	// update_available may be true (baked version < 999.0.0) or false
+	// (running under `go test` where config.Version is unset/"dev"), but
+	// the FIELD must be present once latest_version is known so the SPA
+	// has something to gate on.
+	if _, ok := body["update_available"]; !ok {
+		t.Errorf("update_available missing despite latest_version=%v: %+v",
+			body["latest_version"], body)
+	}
+}
+
 func TestHandleConnectivitySnapshot(t *testing.T) {
 	s := newTestServer(t, false)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connectivity", nil)

--- a/stack/emos-cli/internal/server/server.go
+++ b/stack/emos-cli/internal/server/server.go
@@ -12,10 +12,12 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/automatika-robotics/emos-cli/internal/config"
 	"github.com/automatika-robotics/emos-cli/internal/tlsca"
+	"github.com/automatika-robotics/emos-cli/internal/updcheck"
 )
 
 // Options configures the daemon at boot.
@@ -48,6 +50,34 @@ type Server struct {
 	httpServer *http.Server
 	mdns       *mdnsRegistrations
 	tlsInfo    *tlsca.Info // nil when serving plain HTTP
+
+	// updates caches the latest release tag for /info to surface. Empty
+	// until the first successful refresh; refreshed by a goroutine spawned
+	// in Run().
+	updates updateState
+}
+
+// updateState is the daemon's in-memory copy of the latest release tag.
+// Mutated only from the refresh goroutine; read by /info via Snapshot().
+type updateState struct {
+	mu        sync.RWMutex
+	latest    string // GitHub tag with the leading "v" stripped; "" before first success
+	checkedAt time.Time
+}
+
+// Snapshot returns a copy of the current update state.
+func (u *updateState) Snapshot() (latest string, checkedAt time.Time) {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	return u.latest, u.checkedAt
+}
+
+// set is called by the refresh goroutine on a successful Latest() lookup.
+func (u *updateState) set(latest string) {
+	u.mu.Lock()
+	u.latest = latest
+	u.checkedAt = time.Now()
+	u.mu.Unlock()
 }
 
 // New constructs a Server with all subsystems initialised. The pairing code,
@@ -136,6 +166,10 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}
 
+	// Background loop that refreshes the cached "latest release" tag.
+	// Tied to ctx so it exits cleanly with the rest of the daemon.
+	go s.refreshUpdatesLoop(ctx)
+
 	errCh := make(chan error, 1)
 	go func() {
 		s.log.Info("dashboard listening", "addr", s.opts.Addr, "scheme", s.Scheme())
@@ -170,6 +204,42 @@ func (s *Server) Run(ctx context.Context) error {
 // PairingCode returns the freshly-generated pairing code (one-time per process)
 // for the CLI to display, or "" if pairing was already configured.
 func (s *Server) PairingCode() string { return s.auth.FreshPairingCode() }
+
+// refreshUpdatesLoop calls updcheck.Latest() at startup and on a ticker.
+// Exits when ctx is cancelled, which happens at daemon shutdown.
+func (s *Server) refreshUpdatesLoop(ctx context.Context) {
+	s.tryRefreshUpdates(ctx)
+
+	ticker := time.NewTicker(updcheck.DefaultRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.tryRefreshUpdates(ctx)
+		}
+	}
+}
+
+// tryRefreshUpdates performs a single best-effort GitHub releases lookup.
+// Skipped entirely when connectivity is known-offline (avoids burning a
+// fetch on a slow-failing DNS during early boot, when network-online
+// hasn't actually settled yet).
+func (s *Server) tryRefreshUpdates(ctx context.Context) {
+	if !s.conn.Online(ctx) {
+		s.log.Debug("update check skipped: offline")
+		return
+	}
+	fetchCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	latest, err := updcheck.Latest(fetchCtx)
+	if err != nil {
+		s.log.Debug("update check failed", "err", err)
+		return
+	}
+	s.updates.set(latest)
+}
 
 // modeOrUnknown returns the install mode for diagnostics, or "unknown"
 // when there's no install (no config or a pre-install stub).

--- a/stack/emos-cli/internal/updcheck/updcheck.go
+++ b/stack/emos-cli/internal/updcheck/updcheck.go
@@ -24,6 +24,12 @@ import (
 // Lives under config.ConfigDir.
 const cacheFileName = "update-cache.json"
 
+// DefaultRefreshInterval is the cadence at which both the CLI's
+// RefreshIfStale TTL and the daemon's background ticker consult GitHub
+// for the latest release tag. 6h sits well under the unauthenticated
+// rate limit for Github.
+const DefaultRefreshInterval = 6 * time.Hour
+
 // httpClient bounds the GitHub lookup. The CLI runs interactively and the
 // daemon refreshes asynchronously, so a slow response only stalls one
 // goroutine.

--- a/stack/emos-cli/internal/updcheck/updcheck.go
+++ b/stack/emos-cli/internal/updcheck/updcheck.go
@@ -1,0 +1,230 @@
+// Package updcheck checks whether a newer EMOS release is available. It queries
+// github release api and caches latest results with a TTL
+
+package updcheck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/automatika-robotics/emos-cli/internal/config"
+)
+
+// cacheFileName is the JSON document that holds the last successful fetch.
+// Lives under config.ConfigDir.
+const cacheFileName = "update-cache.json"
+
+// httpClient bounds the GitHub lookup. The CLI runs interactively and the
+// daemon refreshes asynchronously, so a slow response only stalls one
+// goroutine.
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
+// refreshMu serialises in-process background refreshes started by
+// RefreshIfStale.
+var refreshMu sync.Mutex
+
+// cacheFile struct on disk.
+type cacheFile struct {
+	Latest    string    `json:"latest"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// Latest fetches the latest release tag from GitHub. Returns the tag with
+// the leading "v" stripped
+func Latest(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, config.ReleasesURL(), nil)
+	if err != nil {
+		return "", fmt.Errorf("build releases request: %w", err)
+	}
+	// GitHub's API serves /releases/latest with HTML content negotiation
+	// off by default, being explicit
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("github releases API unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Cap the body so a misconfigured upstream can't blow up memory
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("read releases response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github releases API returned HTTP %d", resp.StatusCode)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &release); err != nil {
+		return "", fmt.Errorf("parse releases response: %w", err)
+	}
+	tag := strings.TrimPrefix(release.TagName, "v")
+	if tag == "" {
+		return "", errors.New("github releases API returned an empty tag_name")
+	}
+	return tag, nil
+}
+
+// CachedLatest returns the last successful Latest() value and its
+// timestamp. ok=false if the cache file is absent or unreadable.
+func CachedLatest() (latest string, checkedAt time.Time, ok bool) {
+	path := cachePath()
+	if path == "" {
+		return "", time.Time{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", time.Time{}, false
+	}
+	var c cacheFile
+	if err := json.Unmarshal(data, &c); err != nil {
+		return "", time.Time{}, false
+	}
+	if c.Latest == "" {
+		return "", time.Time{}, false
+	}
+	return c.Latest, c.CheckedAt, true
+}
+
+// RefreshIfStale returns the cached `latest` value and refreshes it when
+// stale. Two refresh modes:
+//   - On a cache miss (no prior value on disk) the function blocks for
+//     up to firstFetchTimeout to perform a synchronous fetch.
+//   - On a stale cache hit (value present but older than ttl) the
+//     function returns the stale value immediately and refreshes
+//     asynchronously.
+func RefreshIfStale(ttl time.Duration) (cachedLatest string, cachedOK bool) {
+	var checkedAt time.Time
+	cachedLatest, checkedAt, cachedOK = CachedLatest()
+	if cachedOK && time.Since(checkedAt) < ttl {
+		return cachedLatest, cachedOK
+	}
+	// Only one refresh in flight at a time. On fail, assume another
+	// goroutine is already doing the work. Return
+	if !refreshMu.TryLock() {
+		return cachedLatest, cachedOK
+	}
+
+	if !cachedOK {
+		// Cache miss; block synchronously so the calling CLI command
+		// has something to show on its first execution.
+		defer refreshMu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), firstFetchTimeout)
+		defer cancel()
+		fresh, err := Latest(ctx)
+		if err != nil {
+			return "", false
+		}
+		_ = writeCache(fresh, time.Now().UTC())
+		return fresh, true
+	}
+
+	// Stale cache; return what we have, refresh in background.
+	go func() {
+		defer refreshMu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), backgroundFetchTimeout)
+		defer cancel()
+		fresh, err := Latest(ctx)
+		if err != nil {
+			return
+		}
+		_ = writeCache(fresh, time.Now().UTC())
+	}()
+	return cachedLatest, cachedOK
+}
+
+// firstFetchTimeout bounds the blocking first-fetch.
+var firstFetchTimeout = 2 * time.Second
+
+// backgroundFetchTimeout bounds an async refresh of a stale cache. Higher
+// than firstFetchTimeout because nobody is waiting on it.
+var backgroundFetchTimeout = 8 * time.Second
+
+// IsNewer reports whether `latest` is strictly newer than `current` under
+// a small X.Y.Z dotted-int comparison. Simple comparison.
+func IsNewer(current, latest string) bool {
+	if current == "" || current == "dev" || latest == "" {
+		return false
+	}
+	c, ok := parseXYZ(current)
+	if !ok {
+		return false
+	}
+	l, ok := parseXYZ(latest)
+	if !ok {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		if l[i] > c[i] {
+			return true
+		}
+		if l[i] < c[i] {
+			return false
+		}
+	}
+	return false
+}
+
+// parseXYZ splits "1.2.3" (or "v1.2.3") into [1, 2, 3]. Returns ok=false
+// if any of the first three dot-separated parts isn't a non-negative int.
+func parseXYZ(s string) ([3]int, bool) {
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.SplitN(s, ".", 4)
+	if len(parts) < 3 {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for i := 0; i < 3; i++ {
+		n, err := strconv.Atoi(parts[i])
+		if err != nil || n < 0 {
+			return [3]int{}, false
+		}
+		out[i] = n
+	}
+	return out, true
+}
+
+// cachePath returns the absolute path of the cache file, or "" if
+// config.ConfigDir is unset (which only happens before config.Init()).
+func cachePath() string {
+	if config.ConfigDir == "" {
+		return ""
+	}
+	return filepath.Join(config.ConfigDir, cacheFileName)
+}
+
+// writeCache persists a successful fetch. Best-effort: errors are
+// returned but callers ignore them (the next refresh will retry).
+func writeCache(latest string, checkedAt time.Time) error {
+	path := cachePath()
+	if path == "" {
+		return errors.New("config.ConfigDir not set")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(cacheFile{Latest: latest, CheckedAt: checkedAt})
+	if err != nil {
+		return err
+	}
+	// Atomic write: Owned by user. Stale .tmp on a crashed write is rare
+	// and harmless (next call truncates).
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/stack/emos-cli/internal/updcheck/updcheck_test.go
+++ b/stack/emos-cli/internal/updcheck/updcheck_test.go
@@ -1,0 +1,296 @@
+package updcheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/automatika-robotics/emos-cli/internal/config"
+)
+
+// withFakeReleases redirects config.ReleasesURL() at a httptest.Server for
+// the duration of the test by overriding the GitHub host through
+// http.DefaultTransport... actually that's hard. Instead we monkey-patch
+// the package-level httpClient with one that rewrites the request URL via
+// a custom RoundTripper. This avoids depending on config internals.
+func withFakeReleases(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	origClient := httpClient
+	t.Cleanup(func() { httpClient = origClient })
+
+	target, _ := url.Parse(srv.URL)
+	httpClient = &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: rewriteRT{target: target},
+	}
+	return srv
+}
+
+// rewriteRT routes every request to the test server, preserving path
+// and query so the handler can still gate on them if needed.
+type rewriteRT struct{ target *url.URL }
+
+func (r rewriteRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = r.target.Scheme
+	req.URL.Host = r.target.Host
+	req.Host = r.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// withTmpConfigDir redirects config.ConfigDir at a fresh tempdir for the
+// duration of the test.
+func withTmpConfigDir(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	orig := config.ConfigDir
+	config.ConfigDir = tmp
+	t.Cleanup(func() { config.ConfigDir = orig })
+	return tmp
+}
+
+func TestLatest_HappyPath(t *testing.T) {
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v0.7.0"}`))
+	})
+	got, err := Latest(context.Background())
+	if err != nil {
+		t.Fatalf("Latest err = %v", err)
+	}
+	if got != "0.7.0" {
+		t.Errorf("Latest = %q, want %q (no leading v)", got, "0.7.0")
+	}
+}
+
+func TestLatest_404(t *testing.T) {
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	if _, err := Latest(context.Background()); err == nil {
+		t.Fatal("expected an error for a 404 response, got nil")
+	}
+}
+
+func TestLatest_MalformedJSON(t *testing.T) {
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{ not json `))
+	})
+	if _, err := Latest(context.Background()); err == nil {
+		t.Fatal("expected an error for malformed JSON, got nil")
+	}
+}
+
+func TestLatest_EmptyTagName(t *testing.T) {
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":""}`))
+	})
+	if _, err := Latest(context.Background()); err == nil {
+		t.Fatal("expected an error for empty tag_name, got nil")
+	}
+}
+
+func TestIsNewer_Table(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+	}{
+		{"0.6.1", "0.7.0", true},
+		{"0.7.0", "0.6.1", false},
+		{"0.7.0", "0.7.0", false},
+		{"1.2.9", "1.2.10", true}, // numeric, not lexicographic
+		{"1.2.10", "1.2.9", false},
+		{"0.0.0", "0.0.1", true},
+		// dev / empty inputs -> never newer
+		{"dev", "9.9.9", false},
+		{"", "9.9.9", false},
+		{"0.6.1", "", false},
+		// malformed -> false (no panic)
+		{"abc", "0.7.0", false},
+		{"0.6.1", "x.y.z", false},
+		{"0.6", "0.7.0", false}, // missing patch
+		// leading v on either side is tolerated
+		{"v0.6.1", "v0.7.0", true},
+	}
+	for _, tc := range cases {
+		got := IsNewer(tc.current, tc.latest)
+		if got != tc.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+		}
+	}
+}
+
+func TestCachedLatest_RoundTrip(t *testing.T) {
+	withTmpConfigDir(t)
+	if err := writeCache("0.7.0", time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("writeCache: %v", err)
+	}
+	latest, checkedAt, ok := CachedLatest()
+	if !ok {
+		t.Fatal("CachedLatest ok=false after writeCache")
+	}
+	if latest != "0.7.0" {
+		t.Errorf("latest = %q, want 0.7.0", latest)
+	}
+	if !checkedAt.Equal(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)) {
+		t.Errorf("checkedAt = %v, want 2026-05-21T12:00:00Z", checkedAt)
+	}
+}
+
+func TestCachedLatest_MissingFile(t *testing.T) {
+	withTmpConfigDir(t)
+	_, _, ok := CachedLatest()
+	if ok {
+		t.Fatal("CachedLatest ok=true on empty config dir")
+	}
+}
+
+func TestCachedLatest_CorruptedJSON(t *testing.T) {
+	tmp := withTmpConfigDir(t)
+	if err := os.WriteFile(filepath.Join(tmp, cacheFileName), []byte(`{not json`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, ok := CachedLatest()
+	if ok {
+		t.Fatal("CachedLatest ok=true on corrupted JSON")
+	}
+}
+
+func TestRefreshIfStale_FreshCacheNoFetch(t *testing.T) {
+	withTmpConfigDir(t)
+	// Pre-seed a fresh cache; the fake server would fail the test if hit.
+	if err := writeCache("0.7.0", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Latest was called even though the cache is fresh")
+	})
+
+	latest, ok := RefreshIfStale(6 * time.Hour)
+	if !ok || latest != "0.7.0" {
+		t.Errorf("RefreshIfStale = (%q, %v), want (0.7.0, true)", latest, ok)
+	}
+	// Give any erroneous goroutine a moment to fire.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestRefreshIfStale_StaleCacheRefreshesInBackground(t *testing.T) {
+	tmp := withTmpConfigDir(t)
+	// Pre-seed a stale cache.
+	stale := time.Now().Add(-24 * time.Hour).UTC()
+	if err := writeCache("0.6.0", stale); err != nil {
+		t.Fatal(err)
+	}
+
+	fetched := make(chan struct{})
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v0.7.0"}`))
+		close(fetched)
+	})
+
+	latest, ok := RefreshIfStale(6 * time.Hour)
+	// Returns the stale value immediately; background goroutine refreshes.
+	if !ok || latest != "0.6.0" {
+		t.Errorf("RefreshIfStale = (%q, %v), want (0.6.0, true) on first call", latest, ok)
+	}
+
+	// Wait for the background fetch to complete.
+	select {
+	case <-fetched:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background refresh never hit the fake server")
+	}
+
+	// Give the goroutine a moment to write the cache file after the
+	// HTTP handler returned.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		latest, _, _ := CachedLatest()
+		if latest == "0.7.0" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	updated, _, ok := CachedLatest()
+	if !ok || updated != "0.7.0" {
+		// One more diagnostic: dump the cache file so the failure is
+		// debuggable.
+		data, _ := os.ReadFile(filepath.Join(tmp, cacheFileName))
+		t.Fatalf("cache not refreshed: latest=%q ok=%v file=%q", updated, ok, string(data))
+	}
+}
+
+func TestRefreshIfStale_CacheMissBlocksAndPopulates(t *testing.T) {
+	// First-ever invocation: no cache file on disk. The function MUST
+	// block-and-fetch so a CLI one-shot has something to show. The
+	// goroutine-only path would never write the cache before the CLI
+	// process exits.
+	withTmpConfigDir(t)
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v0.7.0"}`))
+	})
+
+	latest, ok := RefreshIfStale(6 * time.Hour)
+	if !ok || latest != "0.7.0" {
+		t.Fatalf("RefreshIfStale on cache miss = (%q, %v), want (0.7.0, true)", latest, ok)
+	}
+	// And the cache file is on disk: subsequent invocations skip the fetch.
+	if cached, _, ok := CachedLatest(); !ok || cached != "0.7.0" {
+		t.Errorf("cache not persisted after blocking fetch: cached=%q ok=%v", cached, ok)
+	}
+}
+
+func TestRefreshIfStale_CacheMissFetchFailureReturnsUnknown(t *testing.T) {
+	// Cache miss + offline / 5xx -> ok=false, no panic, no cache write.
+	withTmpConfigDir(t)
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	// Shrink the first-fetch timeout so the test stays snappy.
+	origTimeout := firstFetchTimeout
+	firstFetchTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { firstFetchTimeout = origTimeout })
+
+	_, ok := RefreshIfStale(6 * time.Hour)
+	if ok {
+		t.Errorf("RefreshIfStale on cache miss + 5xx returned ok=true; want false")
+	}
+	if _, _, cachedOK := CachedLatest(); cachedOK {
+		t.Errorf("failed first-fetch wrote a cache file; should leave disk untouched")
+	}
+}
+
+func TestRefreshIfStale_FetchFailureKeepsCache(t *testing.T) {
+	tmp := withTmpConfigDir(t)
+	stale := time.Now().Add(-24 * time.Hour).UTC()
+	if err := writeCache("0.6.0", stale); err != nil {
+		t.Fatal(err)
+	}
+	withFakeReleases(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	latest, ok := RefreshIfStale(6 * time.Hour)
+	if !ok || latest != "0.6.0" {
+		t.Errorf("RefreshIfStale = (%q, %v), want stale (0.6.0, true)", latest, ok)
+	}
+
+	// Even after the failed refresh settles, the cache stays at 0.6.0.
+	time.Sleep(200 * time.Millisecond)
+	updated, _, ok := CachedLatest()
+	if !ok || updated != "0.6.0" {
+		data, _ := os.ReadFile(filepath.Join(tmp, cacheFileName))
+		t.Fatalf("failed refresh clobbered the cache: latest=%q ok=%v file=%q", updated, ok, string(data))
+	}
+}

--- a/stack/emos-cli/web/src/lib/api.ts
+++ b/stack/emos-cli/web/src/lib/api.ts
@@ -44,6 +44,10 @@ export interface Info {
   recipes_dir: string;
   logs_dir: string;
   home_dir: string;
+  // Populated by the daemon's background release-check loop. Absent until
+  // the first successful refresh; absent on offline boots.
+  latest_version?: string;
+  update_available?: boolean;
 }
 
 export interface Capabilities {

--- a/stack/emos-cli/web/src/routes/System.svelte
+++ b/stack/emos-cli/web/src/routes/System.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Wifi, WifiOff, RefreshCw, KeyRound } from 'lucide-svelte';
+  import { Wifi, WifiOff, RefreshCw, KeyRound, ArrowUpCircle } from 'lucide-svelte';
   import { useInfo, useCapabilities, useConnectivity, useRobot } from '$lib/queries';
   import { api } from '$lib/api';
   import { clearToken } from '$lib/auth';
@@ -40,7 +40,21 @@
     <div class="surface p-5 space-y-2">
       <div class="text-xs uppercase tracking-wider text-emos-text-3">EMOS</div>
       <div class="grid grid-cols-2 gap-y-1 text-sm">
-        <div class="text-emos-text-3">version</div><div class="font-mono">{$info.data?.version ?? '—'}</div>
+        <div class="text-emos-text-3">version</div>
+        <div class="font-mono flex items-center gap-2">
+          <span>{$info.data?.version ?? '—'}</span>
+          {#if $info.data?.update_available && $info.data?.latest_version}
+            <a
+              href={`https://github.com/automatika-robotics/emos/releases/tag/v${$info.data.latest_version}`}
+              target="_blank"
+              rel="noopener"
+              class="pill pill-good text-[0.7rem]"
+              title="A newer release of EMOS is available"
+            >
+              <ArrowUpCircle size={12} /> v{$info.data.latest_version}
+            </a>
+          {/if}
+        </div>
         <div class="text-emos-text-3">uptime</div><div class="font-mono">{$info.data?.uptime ?? '—'}</div>
         <div class="text-emos-text-3">install</div><div>{$info.data?.mode ?? '—'}</div>
         <div class="text-emos-text-3">ros</div><div>{$info.data?.ros_distro ?? '—'}</div>


### PR DESCRIPTION
## Summary

Closes #9.

EMOS now tells users when a newer release is available. The CLI prints a one-line nudge below the version readout on `emos status` and `emos version`. The dashboard's **System** page shows a small green pill next to the version row, linking to the GitHub release. 

Silent when up-to-date, offline or for `dev` builds.

## What's in the change

**New shared helper -- `internal/updcheck`.** Fetches the latest tag via `config.ReleasesURL()`, caches the result on disk at `~/.config/emos/update-cache.json` with a 6-hour TTL, and exposes a small API: `Latest`, `CachedLatest`, `RefreshIfStale`, `IsNewer`. The interval `DefaultRefreshInterval = 6 * time.Hour` is the single source of truth -- both consumers reference it.

`RefreshIfStale` has two modes: on a cache miss it blocks synchronously for up to 2s (so a one-shot CLI invocation can populate the cache on first run); on a stale hit it returns the stale value immediately and refreshes asynchronously. `IsNewer` is a plain X.Y.Z dotted-int compare; treats `current == "dev"` and any malformed input as never-newer.

The existing `selfUpdateCLI` (`cmd/update.go`) is refactored to call `updcheck.Latest` instead of its inlined HTTP+JSON code. It still hits `/releases/latest` a second time when an actual update is going ahead, because the asset list (per-arch download URLs) isn't needed elsewhere and not worth folding into the cache shape.

**CLI surface.** `cmd/status.go` and `cmd/root.go` (`versionCmd`) call a shared `printUpdateAvailable()` which consults `updcheck.RefreshIfStale` and prints the line only when a strictly-newer tag exists. No new flags, no command-graph changes.

**Daemon surface.** `Server` gains an in-memory `updateState` (mutex-guarded latest tag + checked-at). `Server.Run` spawns a goroutine that calls `updcheck.Latest` at startup and on a ticker, gated by the existing `s.conn.Online()` check so an offline boot doesn't burn time on a doomed DNS lookup. `/api/v1/info` emits `latest_version` and `update_available` only once the first refresh has succeeded -- the fields stay absent before that so a schema-aware client can distinguish "no value yet" from "up-to-date".

**SPA.** `Info` interface gains optional `latest_version` and `update_available`. `System.svelte` renders a small \`↑ vX.Y.Z\` pill next to the version row when `update_available` is true, linking to `https://github.com/automatika-robotics/emos/releases/tag/v<latest>`. 